### PR TITLE
add hq upgrade cancellation and team chronicle events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,7 @@ docker exec -u apache fantager-web composer phpstan
 ## English
 
 Documentation and code comments are in English (see copilot-instructions).
+
+## Strict constraints
+
+1. **No LaTeX syntax**: Never use LaTeX formatting, syntax, or mathematical notations (such as `$$...$$` or `$...$`) under any circumstances. All mathematical expressions and formulas must be written in plain, readable text (e.g., `a + b = c`).

--- a/assets/controllers/hq_controller.js
+++ b/assets/controllers/hq_controller.js
@@ -14,8 +14,13 @@ export default class extends Controller {
         errorDowngrade: String,
         successUpgrade: String,
         successDowngrade: String,
+        titleUpgrade: String,
+        confirmUpgrade: String,
         titleDowngrade: String,
         confirmDowngrade: String,
+        titleCancelUpgrade: String,
+        confirmCancelUpgrade: String,
+        successCancelUpgrade: String,
         textSaving: String,
         errorAdaptation: String,
         successAdaptation: String,
@@ -40,6 +45,22 @@ export default class extends Controller {
         e.preventDefault();
         const btn = e.currentTarget;
         const facilityType = btn.dataset.facility;
+        const cost = btn.dataset.cost || '0';
+        const duration = btn.dataset.duration || '0';
+
+        const confirmMsg = this.confirmUpgradeValue
+            .replace('%cost%', formatNumber(parseInt(cost, 10)))
+            .replace('%duration%', duration);
+
+        if (!await showConfirm(
+            this.titleUpgradeValue || 'Upgrade Facility',
+            confirmMsg,
+            this.titleUpgradeValue,
+            null, // Default to Cancel
+            'primary'
+        )) {
+            return;
+        }
 
         // Disable all upgrade buttons to prevent double-clicks
         this.setButtonsDisabled(true);
@@ -164,6 +185,52 @@ export default class extends Controller {
         }
     }
 
+    async cancelUpgrade(e) {
+        e.preventDefault();
+        const btn = e.currentTarget;
+        const cost = btn.dataset.cost || '0';
+
+        const confirmMsg = this.confirmCancelUpgradeValue
+            .replace('%cost%', formatNumber(parseInt(cost, 10)));
+
+        if (!await showConfirm(
+            this.titleCancelUpgradeValue || 'Cancel Upgrade',
+            confirmMsg,
+            this.titleCancelUpgradeValue,
+            null, // Default to Cancel
+            'danger'
+        )) {
+            return;
+        }
+
+        this.setButtonsDisabled(true);
+        const originalText = btn.textContent;
+        btn.textContent = this.textSavingValue || 'Processing...';
+
+        try {
+            const response = await fetch('/api/v1/hq/cancel-upgrade', {
+                method: 'POST',
+                headers: csrfHeaders({ 'Content-Type': 'application/json' })
+            });
+
+            const result = await response.json();
+
+            if (!response.ok || result.error) {
+                throw new Error(result.error || this.successCancelUpgradeValue);
+            }
+
+            this.showAlert('success', this.successCancelUpgradeValue);
+
+            setTimeout(() => {
+                window.location.reload();
+            }, 1000);
+        } catch (error) {
+            this.showAlert('error', error.message);
+            this.setButtonsDisabled(false);
+            btn.textContent = originalText;
+        }
+    }
+
     /** Save a pending arena adaptation change (POST /api/v1/hq/optimize). */
     async saveArenaAdaptation(e) {
         e.preventDefault();
@@ -200,7 +267,7 @@ export default class extends Controller {
     }
 
     setButtonsDisabled(disabled) {
-        this.element.querySelectorAll('[data-action="click->hq#upgrade"], [data-action="click->hq#downgrade"]').forEach(b => {
+        this.element.querySelectorAll('[data-action="click->hq#upgrade"], [data-action="click->hq#downgrade"], [data-action="click->hq#cancelUpgrade"]').forEach(b => {
             b.disabled = disabled;
         });
     }

--- a/assets/styles/components/_arena.scss
+++ b/assets/styles/components/_arena.scss
@@ -10,17 +10,36 @@
   }
 
   .arena-stat-card {
-    @apply rounded-xl p-4 text-center;
+    @apply rounded-xl p-4 text-center transition-all duration-150 flex flex-col items-center justify-between gap-2;
     background-color: color-mix(in srgb, var(--color-surface-overlay) 50%, transparent);
     border: 1px solid var(--color-border);
+    min-height: 8.75rem;
+
+    &:hover {
+      border-color: color-mix(in srgb, var(--color-brand-500) 40%, var(--color-border));
+      background-color: color-mix(in srgb, var(--color-surface-overlay) 65%, transparent);
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px color-mix(in srgb, black 20%, transparent);
+    }
+
+    &__icon-wrapper {
+      @apply w-9 h-9 rounded-full flex items-center justify-center;
+      background-color: color-mix(in srgb, var(--color-surface-base) 60%, transparent);
+      border: 1px solid var(--color-border);
+    }
+
+    &__icon {
+      @apply text-base select-none;
+    }
 
     &__label {
-      @apply text-[10px] uppercase font-bold tracking-wider mb-1;
+      @apply text-[9px] uppercase font-bold tracking-wider block leading-tight;
       color: var(--color-text-muted);
+      max-width: 100%;
     }
 
     &__value {
-      @apply text-2xl font-extrabold;
+      @apply text-xl font-extrabold block;
       color: var(--color-text-primary);
     }
 
@@ -34,6 +53,69 @@
       &--negative {
         color: var(--color-error-text);
       }
+    }
+  }
+
+  .arena-match-card {
+    @apply rounded-xl p-4 flex flex-col gap-3 transition-all;
+    background-color: color-mix(in srgb, var(--color-surface-overlay) 35%, transparent);
+    border: 1px solid var(--color-border);
+
+    &:hover {
+      border-color: color-mix(in srgb, var(--color-brand-500) 25%, var(--color-border));
+    }
+
+    &__header {
+      @apply flex justify-between items-center text-xs;
+      color: var(--color-text-muted);
+    }
+
+    &__badge {
+      @apply px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider;
+      background-color: color-mix(in srgb, var(--color-brand-500) 10%, transparent);
+      color: var(--color-brand-400);
+      border: 1px solid color-mix(in srgb, var(--color-brand-500) 20%, transparent);
+    }
+
+    &__date {
+      @apply font-medium;
+      color: var(--color-text-secondary);
+    }
+
+    &__vs-wrapper {
+      @apply flex items-center justify-between gap-4 py-2 text-center;
+    }
+
+    &__team-name {
+      @apply text-base font-bold flex-1 text-right;
+      color: var(--color-text-primary);
+    }
+
+    &__vs {
+      @apply px-2 py-1 rounded text-[10px] font-extrabold;
+      background-color: var(--color-surface-base);
+      border: 1px solid var(--color-border);
+      color: var(--color-text-muted);
+    }
+
+    &__opponent {
+      @apply text-base font-bold flex-1 text-left;
+      color: var(--color-brand-400);
+    }
+
+    &__footer {
+      @apply flex justify-between items-center pt-3 border-t;
+      border-color: var(--color-border);
+    }
+
+    &__projected-label {
+      @apply text-xs font-semibold;
+      color: var(--color-text-secondary);
+    }
+
+    &__projected-value {
+      @apply text-base font-bold;
+      color: var(--color-amber-400);
     }
   }
 }
@@ -59,11 +141,44 @@
   color: var(--color-text-muted);
   border-bottom: 1px solid var(--color-border);
 }
-.arena-revenue-table tbody tr { border-bottom: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent); }
+.arena-revenue-table tbody tr {
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+  transition: background-color var(--transition-fast);
+  &:hover {
+    background-color: var(--overlay-white-03);
+  }
+}
 .arena-revenue-table__th { @apply py-2 pr-4; }
 .arena-revenue-table__cell-date { @apply py-2 pr-4; color: var(--color-text-secondary); }
 .arena-revenue-table__cell-muted { @apply py-2 pr-4; color: var(--color-text-secondary); }
 .arena-revenue-table__cell-amount { @apply py-2 font-semibold; color: var(--color-success-text); }
-.arena-rules-list { @apply text-sm space-y-2 list-disc list-inside; color: var(--color-text-secondary); }
+
+.arena-rules-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  li {
+    position: relative;
+    padding-left: 1.5rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: var(--color-text-secondary);
+
+    &::before {
+      content: "•";
+      position: absolute;
+      left: 0.5rem;
+      top: 0;
+      color: var(--color-brand-400);
+      font-weight: bold;
+      font-size: 1.125rem;
+    }
+  }
+}
+
 .arena-upgrade-hint { @apply text-[11px] mt-4; color: color-mix(in srgb, var(--color-text-muted) 85%, transparent); }
 .arena-empty-copy { @apply text-sm; color: var(--color-text-muted); }

--- a/assets/styles/components/_hq.scss
+++ b/assets/styles/components/_hq.scss
@@ -10,6 +10,14 @@
     gap: 1rem;
   }
 
+  .hq-upgrade-banner-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    gap: 1rem;
+  }
+
   .facility-card {
     @apply flex flex-col justify-between rounded-2xl p-5 shadow-md transition-all;
     background-color: color-mix(in srgb, var(--color-surface-overlay) 40%, transparent);

--- a/assets/styles/components/_hq.scss
+++ b/assets/styles/components/_hq.scss
@@ -15,6 +15,7 @@
     background-color: color-mix(in srgb, var(--color-surface-overlay) 40%, transparent);
     border: 1px solid var(--color-border);
     backdrop-filter: blur(12px);
+    position: relative;
 
     &:hover {
       border-color: color-mix(in srgb, var(--color-brand-500) 25%, var(--color-border));
@@ -25,6 +26,39 @@
       list-style: none;
       padding: 0;
       margin: 0;
+    }
+
+    &--locked {
+      border-color: var(--color-warning-border);
+      background-color: color-mix(in srgb, var(--color-warning-bg) 15%, color-mix(in srgb, var(--color-surface-overlay) 40%, transparent));
+
+      &:hover {
+        border-color: var(--color-warning-text);
+      }
+    }
+
+    &__lock-indicator {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      width: 1.25rem;
+      height: 1.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      background-color: var(--color-warning-bg);
+      border: 1px solid var(--color-warning-border);
+      color: var(--color-warning-text);
+      font-size: 0.75rem;
+      font-weight: bold;
+      cursor: help;
+      transition: all var(--transition-fast);
+
+      &:hover {
+        background-color: var(--color-warning-border);
+        color: var(--color-white);
+      }
     }
   }
 
@@ -194,6 +228,20 @@
 
   .facility-card--changing {
     border-color: var(--color-info-border);
+    background-color: color-mix(in srgb, var(--color-info-bg) 15%, color-mix(in srgb, var(--color-surface-overlay) 40%, transparent));
+
+    &:hover {
+      border-color: var(--color-info-text);
+    }
+
+    &.facility-card--locked {
+      border-color: var(--color-info-border);
+      background-color: color-mix(in srgb, var(--color-warning-bg) 15%, color-mix(in srgb, var(--color-surface-overlay) 40%, transparent));
+
+      &:hover {
+        border-color: var(--color-info-text);
+      }
+    }
   }
 
   .facility-card__changing-note {
@@ -205,6 +253,11 @@
   .btn--warning {
     border-color: var(--color-warning-border);
     color: var(--color-warning-text);
+  }
+
+  .btn--danger {
+    border-color: var(--color-error-border);
+    color: var(--color-error-text);
   }
 
   .hq-facility-panel__header {

--- a/assets/styles/components/_sidebar.scss
+++ b/assets/styles/components/_sidebar.scss
@@ -53,11 +53,12 @@
   .sidebar-link {
     @apply flex items-center gap-3 px-4 py-2.5 rounded font-medium transition-colors no-underline;
     color: var(--color-text-secondary);
+    border: 1px solid transparent;
     &:hover { background-color: var(--color-surface-overlay); color: var(--color-text-primary); }
     &--active {
       background-color: color-mix(in srgb, var(--color-brand-500) 10%, transparent);
       color: var(--color-brand-400);
-      border: 1px solid color-mix(in srgb, var(--color-brand-500) 20%, transparent);
+      border-color: color-mix(in srgb, var(--color-brand-500) 20%, transparent);
     }
   }
   .sidebar-link__emoji { @apply text-base select-none; }

--- a/docs/route-map.md
+++ b/docs/route-map.md
@@ -124,6 +124,7 @@ Reference: [api-design.md](api-design.md), [screens-overview.md](screens-overvie
 | GET | `/api/v1/hq` | Api\V1\HeadquartersController | Facility levels + bonuses |
 | POST | `/api/v1/hq/upgrade` | Api\V1\HeadquartersController | Upgrade facility |
 | POST | `/api/v1/hq/downgrade` | Api\V1\HeadquartersController | Downgrade facility (financial crisis recovery) |
+| POST | `/api/v1/hq/cancel-upgrade` | Api\V1\HeadquartersController | Cancel ongoing facility upgrade |
 | POST | `/api/v1/hq/optimize` | Api\V1\HeadquartersController | Change arena adaptation |
 
 > Legacy shortcuts `/app/arena` and `/app/summon` redirect into HQ (`?facility=arena` / `?facility=summoning_chamber`).

--- a/src/Controller/Api/V1/HeadquartersController.php
+++ b/src/Controller/Api/V1/HeadquartersController.php
@@ -122,6 +122,24 @@ class HeadquartersController extends AbstractController
         return $this->json($this->hqService->serializeFacility($facility, $type, $this->hqService->getForTeam($team)));
     }
 
+    #[Route('/cancel-upgrade', name: 'api_hq_cancel_upgrade', methods: ['POST'])]
+    public function cancelUpgrade(): JsonResponse
+    {
+        $team = $this->getPlayerTeam();
+        if (null === $team) {
+            return $this->jsonError('error.no_team', 422);
+        }
+
+        try {
+            $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+            $this->hqService->cancelUpgrade($team, $now);
+        } catch (\DomainException $e) {
+            return $this->jsonException($e, 422);
+        }
+
+        return $this->json(['success' => true]);
+    }
+
     /** Schedule an arena adaptation change (route kept as `/optimize` for API stability). */
     #[Route('/optimize', name: 'api_hq_optimize', methods: ['POST'])]
     public function optimize(Request $request): JsonResponse

--- a/src/Enum/ChronicleCategory.php
+++ b/src/Enum/ChronicleCategory.php
@@ -48,6 +48,9 @@ enum ChronicleCategory: string
                 ChronicleEventType::HeroSold,
                 ChronicleEventType::TrainerPurchased,
                 ChronicleEventType::TrainerSold,
+                ChronicleEventType::FacilityUpgraded,
+                ChronicleEventType::FacilityDowngraded,
+                ChronicleEventType::RaceOptimizationChanged,
             ],
         };
     }

--- a/src/Enum/ChronicleEventType.php
+++ b/src/Enum/ChronicleEventType.php
@@ -28,4 +28,7 @@ enum ChronicleEventType: string
     case TrainerPurchased = 'trainer_purchased';
     case TrainerSold = 'trainer_sold';
     case TeamRenamed = 'team_renamed';
+    case FacilityUpgraded = 'facility_upgraded';
+    case FacilityDowngraded = 'facility_downgraded';
+    case RaceOptimizationChanged = 'race_optimization_changed';
 }

--- a/src/Enum/FinancialRecordType.php
+++ b/src/Enum/FinancialRecordType.php
@@ -24,5 +24,6 @@ enum FinancialRecordType: string
     case HeroDismissalCompensation = 'hero_dismissal_compensation';
     case TrainerDismissalCompensation = 'trainer_dismissal_compensation';
     case HqDowngradeRefund = 'hq_downgrade_refund';
+    case HqUpgradeRefund = 'hq_upgrade_refund';
     case KingdomReward = 'kingdom_reward';
 }

--- a/src/Service/Headquarters/HeadquartersService.php
+++ b/src/Service/Headquarters/HeadquartersService.php
@@ -17,6 +17,7 @@ use App\Repository\Headquarters\HeadquartersRepository;
 use App\Service\Economy\EconomyService;
 use App\Service\Economy\FinancialCrisisService;
 use App\Service\Economy\RoyalTreasuryService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use Doctrine\ORM\EntityManagerInterface;
 
 class HeadquartersService
@@ -48,6 +49,7 @@ class HeadquartersService
         private readonly EconomyService $economyService,
         private readonly FinancialCrisisService $financialCrisisService,
         private readonly RoyalTreasuryService $royalTreasuryService,
+        private readonly TeamChronicleService $teamChronicleService,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -157,6 +159,64 @@ class HeadquartersService
         $this->em->flush();
 
         return $facility;
+    }
+
+    /**
+     * Cancel an active upgrade if it was started less than 1 hour ago.
+     * Refunds the full gold cost to the team.
+     *
+     * @throws \DomainException
+     */
+    public function cancelUpgrade(Team $team, \DateTimeImmutable $now): void
+    {
+        $hq = $this->getForTeam($team);
+        $facility = $hq->getUpgradingFacility();
+
+        if (null === $facility) {
+            throw new UserFacingException('error.hq_no_active_upgrade');
+        }
+
+        if (\App\Enum\FacilityOperation::Upgrade !== $hq->getFacilityOperation()) {
+            throw new UserFacingException('error.hq_cannot_cancel_downgrade');
+        }
+
+        $completedAt = $hq->getUpgradeCompletedAt();
+        if (null === $completedAt) {
+            throw new UserFacingException('error.hq_no_active_upgrade');
+        }
+
+        $targetLevel = $facility->getLevel() + 1;
+        $speed = (float) $team->getKingdom()->getGameSpeed();
+        if ($speed <= 0.0) {
+            $speed = 1.0;
+        }
+
+        $seconds = (int) round(($targetLevel * 24 * 3600) / $speed);
+        $startedAt = $completedAt->modify(sprintf('-%d seconds', $seconds));
+
+        $elapsed = $now->getTimestamp() - $startedAt->getTimestamp();
+        if ($elapsed > 3600) {
+            throw new UserFacingException('error.hq_cancel_time_expired');
+        }
+
+        // Calculate refund cost (100% refund of upgrade cost)
+        $cost = $this->calculateUpgradeCost($facility->getType(), $facility->getLevel(), $hq->getComputedTotalLevel());
+
+        // Refund gold and record transaction
+        $this->economyService->addGold(
+            $team,
+            $cost,
+            FinancialRecordType::HqUpgradeRefund,
+            FinancialRecordActor::Active,
+            ['facility_type' => $facility->getType()->value, 'cancelled_level' => $targetLevel]
+        );
+
+        // Reset upgrade state
+        $hq->setUpgradingFacility(null);
+        $hq->setUpgradeCompletedAt(null);
+        $hq->setFacilityOperation(null);
+
+        $this->em->flush();
     }
 
     /**
@@ -415,10 +475,15 @@ class HeadquartersService
         foreach ($hqs as $hq) {
             /** @var Headquarters $hq */
             if ($hq->hasPendingRaceOptimizationChange()) {
-                $hq->setRaceOptimization($hq->getPendingRaceOptimization());
+                $team = $hq->getTeam();
+                $targetRace = $hq->getPendingRaceOptimization();
+
+                $hq->setRaceOptimization($targetRace);
                 $hq->setPendingRaceOptimization(null);
                 $hq->setHasPendingRaceOptimizationChange(false);
                 $hq->setRaceOptimizationLockCycle(true);
+
+                $this->teamChronicleService->recordRaceOptimizationChanged($team, $targetRace);
             } elseif ($hq->isRaceOptimizationLockCycle()) {
                 $hq->setRaceOptimizationLockCycle(false);
             }
@@ -465,8 +530,13 @@ class HeadquartersService
                 }
 
                 $hq->setFacilityDowngradeLockCycle(true);
+
+                $this->teamChronicleService->recordFacilityDowngraded($team, $type->value, $newLevel);
             } else {
-                $changing->setLevel($changing->getLevel() + 1);
+                $newLevel = $changing->getLevel() + 1;
+                $changing->setLevel($newLevel);
+
+                $this->teamChronicleService->recordFacilityUpgraded($team, $type->value, $newLevel);
             }
 
             $hq->setUpgradingFacility(null);

--- a/src/Service/League/LeagueMatchResolutionService.php
+++ b/src/Service/League/LeagueMatchResolutionService.php
@@ -17,6 +17,7 @@ use App\Service\Combat\MatchSimulatorInterface;
 use App\Service\Team\FanClubService;
 use App\Service\Team\TeamMoraleReputationService;
 use App\Service\Team\TeamRosterService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use App\ValueObject\Combat\MatchOutcome;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -31,6 +32,7 @@ class LeagueMatchResolutionService
         private readonly LeagueFixtureCompletionService $fixtureCompletionService,
         private readonly FanClubService $fanClubService,
         private readonly TeamMoraleReputationService $teamMoraleReputationService,
+        private readonly TeamChronicleService $teamChronicleService,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -79,6 +81,21 @@ class LeagueMatchResolutionService
 
         $battle = $this->createBattle($fixture, $outcome, $processedAt);
         $this->em->persist($battle);
+
+        $this->teamChronicleService->recordBattleOutcome(
+            $homeTeam,
+            $awayTeam,
+            $outcome->getHomeScore(),
+            $outcome->getAwayScore(),
+            $battle
+        );
+        $this->teamChronicleService->recordBattleOutcome(
+            $awayTeam,
+            $homeTeam,
+            $outcome->getAwayScore(),
+            $outcome->getHomeScore(),
+            $battle
+        );
 
         $homeStanding = $this->requireStanding($fixture->getGroup(), $homeTeam);
         $awayStanding = $this->requireStanding($fixture->getGroup(), $awayTeam);

--- a/src/Service/TeamChronicle/TeamChroniclePresenter.php
+++ b/src/Service/TeamChronicle/TeamChroniclePresenter.php
@@ -115,6 +115,37 @@ class TeamChroniclePresenter
             $params['race'] = $this->translator->trans($raceKey, [], 'messages', $locale);
         }
 
+        if (ChronicleEventType::TrainingCompleted === $type) {
+            if (isset($params['attribute']) && '' !== $params['attribute']) {
+                $params['attribute'] = $this->translator->trans(
+                    'training.attr.'.$params['attribute'],
+                    [],
+                    'messages',
+                    $locale,
+                );
+            } else {
+                $params['attribute'] = '';
+            }
+        }
+
+        if (in_array($type, [ChronicleEventType::FacilityUpgraded, ChronicleEventType::FacilityDowngraded], true) && isset($params['facility'])) {
+            $params['facility'] = $this->translator->trans(
+                'hq.facilities_list.'.$params['facility'].'.name',
+                [],
+                'messages',
+                $locale,
+            );
+        }
+
+        if (ChronicleEventType::RaceOptimizationChanged === $type && isset($params['race'])) {
+            if ('' !== $params['race']) {
+                $raceKey = 'heroes.race_'.$params['race'];
+                $params['race'] = $this->translator->trans($raceKey, [], 'messages', $locale);
+            } else {
+                $params['race'] = $this->translator->trans('hq.no_opt', [], 'messages', $locale);
+            }
+        }
+
         $transParams = $this->normalizeTransParams($params);
 
         return [
@@ -199,6 +230,9 @@ class TeamChroniclePresenter
             ChronicleEventType::TrainerPurchased => '🛒',
             ChronicleEventType::TrainerSold => '💰',
             ChronicleEventType::TeamRenamed => '🏷️',
+            ChronicleEventType::FacilityUpgraded => '🏗️',
+            ChronicleEventType::FacilityDowngraded => '📉',
+            ChronicleEventType::RaceOptimizationChanged => '🏟️',
         };
     }
 }

--- a/src/Service/TeamChronicle/TeamChronicleService.php
+++ b/src/Service/TeamChronicle/TeamChronicleService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\TeamChronicle;
 
 use App\Entity\Auth\User;
+use App\Entity\Combat\Battle;
 use App\Entity\Hero\Hero;
 use App\Entity\Kingdom\Kingdom;
 use App\Entity\Team\Team;
@@ -242,6 +243,122 @@ class TeamChronicleService
                 'old_name' => $oldName,
                 'new_name' => $newName,
             ],
+        );
+    }
+
+    public function recordBattleOutcome(Team $team, Team $opponent, int $ourScore, int $theirScore, Battle $battle): TeamChronicle
+    {
+        if ($ourScore > $theirScore) {
+            $type = ChronicleEventType::BattleWin;
+            $key = 'activity.battle_win';
+        } elseif ($ourScore < $theirScore) {
+            $type = ChronicleEventType::BattleLoss;
+            $key = 'activity.battle_loss';
+        } else {
+            $type = ChronicleEventType::BattleDraw;
+            $key = 'activity.battle_draw';
+        }
+
+        return $this->create(
+            $team,
+            $type,
+            $key,
+            [
+                'opponent' => $opponent->getName(),
+                'score' => $ourScore.':'.$theirScore,
+            ],
+            [
+                'opponent_team_id' => $opponent->getId(),
+                'our_score' => $ourScore,
+                'their_score' => $theirScore,
+                'battle_id' => $battle->getId(),
+            ]
+        );
+    }
+
+    public function recordTrainingCompleted(
+        Team $team,
+        Hero $hero,
+        Hero $trainer,
+        string $trainingTypeValue,
+        ?string $attribute,
+        int $gainRaw,
+    ): TeamChronicle {
+        $subjectKey = 'activity.training_completed.'.$trainingTypeValue;
+
+        $gainFormatted = '';
+        if ('attribute' === $trainingTypeValue) {
+            $gainFormatted = '+'.number_format($gainRaw / 10, 1);
+        } else {
+            $gainFormatted = '+'.$gainRaw;
+        }
+
+        return $this->create(
+            $team,
+            ChronicleEventType::TrainingCompleted,
+            $subjectKey,
+            [
+                'hero' => $hero->getName(),
+                'trainer' => $trainer->getName(),
+                'attribute' => $attribute ?? '',
+                'gain' => $gainFormatted,
+            ],
+            [
+                'hero_id' => $hero->getId(),
+                'trainer_id' => $trainer->getId(),
+                'type' => $trainingTypeValue,
+                'attribute' => $attribute,
+                'gain_raw' => $gainRaw,
+            ]
+        );
+    }
+
+    public function recordFacilityUpgraded(Team $team, string $facilityType, int $newLevel): TeamChronicle
+    {
+        return $this->create(
+            $team,
+            ChronicleEventType::FacilityUpgraded,
+            'activity.facility_upgraded',
+            [
+                'facility' => $facilityType,
+                'level' => (string) $newLevel,
+            ],
+            [
+                'facility' => $facilityType,
+                'level' => $newLevel,
+            ]
+        );
+    }
+
+    public function recordFacilityDowngraded(Team $team, string $facilityType, int $newLevel): TeamChronicle
+    {
+        return $this->create(
+            $team,
+            ChronicleEventType::FacilityDowngraded,
+            'activity.facility_downgraded',
+            [
+                'facility' => $facilityType,
+                'level' => (string) $newLevel,
+            ],
+            [
+                'facility' => $facilityType,
+                'level' => $newLevel,
+            ]
+        );
+    }
+
+    public function recordRaceOptimizationChanged(Team $team, ?string $race): TeamChronicle
+    {
+        return $this->create(
+            $team,
+            ChronicleEventType::RaceOptimizationChanged,
+            'activity.race_optimization_changed',
+            [
+                'race' => $race ?? '',
+            ],
+            [
+                'race' => $race,
+            ]
         );
     }
 

--- a/src/Service/Training/TrainingService.php
+++ b/src/Service/Training/TrainingService.php
@@ -14,6 +14,7 @@ use App\Exception\UserFacingException;
 use App\Repository\Headquarters\HeadquartersRepository;
 use App\Repository\Hero\HeroRepository;
 use App\Service\Config\RaceConfig;
+use App\Service\TeamChronicle\TeamChronicleService;
 use Doctrine\ORM\EntityManagerInterface;
 
 class TrainingService
@@ -25,6 +26,7 @@ class TrainingService
         private readonly HeroRepository $heroRepository,
         private readonly HeadquartersRepository $hqRepository,
         private readonly RaceConfig $raceConfig,
+        private readonly TeamChronicleService $teamChronicleService,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -336,6 +338,15 @@ class TrainingService
                 $history->setCompletedAt($now);
 
                 $this->em->persist($history);
+
+                $this->teamChronicleService->recordTrainingCompleted(
+                    $hero->getTeam(),
+                    $hero,
+                    $trainer,
+                    $type->value,
+                    $attribute,
+                    $gainRaw
+                );
             }
         }
 

--- a/templates/components/hq/arena_adaptation.html.twig
+++ b/templates/components/hq/arena_adaptation.html.twig
@@ -1,5 +1,12 @@
 {# templates/components/hq/arena_adaptation.html.twig #}
-<div class="facility-card hq-adaptation-card">
+<div class="facility-card hq-adaptation-card{% if is_optimization_locked %} facility-card--locked{% endif %}">
+    {% if is_optimization_locked %}
+        {% set opt_lock_msg = pending_race_optimization
+            ? 'hq.race_opt_pending'|trans({'%race%': ('heroes.race_' ~ pending_race_optimization)|trans})
+            : 'hq.race_opt_locked'|trans
+        %}
+        <div class="facility-card__lock-indicator" title="{{ opt_lock_msg }}">?</div>
+    {% endif %}
     <div class="facility-card__content">
         <div class="facility-card__header">
             <div class="facility-card__identity">

--- a/templates/components/hq/facility_card.html.twig
+++ b/templates/components/hq/facility_card.html.twig
@@ -17,8 +17,33 @@
 {% set can_change = hq and hq.upgradingFacility is null and not hq.facilityDowngradeLockCycle %}
 {% set is_changing = hq and hq.upgradingFacility and hq.upgradingFacility.type.value == key %}
 {% set upgrade_blocked = crisis.level in ['restricted', 'bankruptcy_pending'] %}
+{% set target_level = facility.level + 1 %}
+{% set speed = team.kingdom.gameSpeed %}
+{% set duration_hours = speed > 0 ? ((target_level * 24) / speed)|round(1) : (target_level * 24) %}
 
-<div data-facility-card class="facility-card{% if is_changing %} facility-card--changing{% endif %}">
+{% set is_facility_locked = (key == 'training' and is_locked|default(false))
+    or (key == 'summoning_chamber' and summon_status is defined and not summon_status.available and summon_status.reason in ['error.summoning_limit_reached', 'error.summoning_roster_full'])
+%}
+
+{% set can_cancel = false %}
+{% if is_changing and hq.facilityOperation and hq.facilityOperation.value == 'upgrade' and hq.upgradeCompletedAt %}
+    {% set duration_seconds = speed > 0 ? ((target_level * 24 * 3600) / speed)|round : (target_level * 24 * 3600) %}
+    {% set completed_timestamp = hq.upgradeCompletedAt|date('U') + hq.upgradeCompletedAt|date('Z') %}
+    {% set started_timestamp = completed_timestamp - duration_seconds %}
+    {% set current_timestamp = 'now'|date('U') %}
+    {% if current_timestamp - started_timestamp >= 0 and current_timestamp - started_timestamp < 3600 %}
+        {% set can_cancel = true %}
+    {% endif %}
+{% endif %}
+
+<div data-facility-card class="facility-card{% if is_changing %} facility-card--changing{% endif %}{% if is_facility_locked %} facility-card--locked{% endif %}">
+    {% if is_facility_locked %}
+        {% set lock_tooltip = key == 'training'
+            ? 'training.lock_warning'|trans
+            : summon_status.reason|trans
+        %}
+        <div class="facility-card__lock-indicator" title="{{ lock_tooltip }}">?</div>
+    {% endif %}
     <div class="facility-card__content">
         <div class="facility-card__header">
             <div class="facility-card__identity">
@@ -107,29 +132,43 @@
                     {{ 'hq.manage_facility'|trans }}
                 </button>
             {% endif %}
-            {% if facility.level > 1 %}
+            {% if is_changing %}
+                {% if can_cancel %}
+                    <button type="button"
+                            data-action="click->hq#cancelUpgrade"
+                            data-facility="{{ key }}"
+                            data-cost="{{ upgrade_cost }}"
+                            class="btn btn-outline btn--sm btn--danger"
+                            aria-label="{{ 'hq.cancel_upgrade_btn'|trans }}">
+                        {{ 'hq.cancel_upgrade_btn'|trans }}
+                    </button>
+                {% endif %}
+            {% else %}
+                {% if facility.level > 1 %}
+                    <button type="button"
+                            data-action="click->hq#downgrade"
+                            data-facility="{{ key }}"
+                            data-refund="{{ downgrade_refund }}"
+                            {% if not can_change %}disabled title="{{ 'hq.facility_change_locked'|trans }}"{% endif %}
+                            class="btn btn-outline btn--sm btn--warning"
+                            aria-label="{{ 'hq.downgrade_btn'|trans }}">
+                        {{ 'hq.downgrade_btn'|trans }}
+                    </button>
+                {% endif %}
                 <button type="button"
-                        data-action="click->hq#downgrade"
+                        data-action="click->hq#upgrade"
                         data-facility="{{ key }}"
-                        data-refund="{{ downgrade_refund }}"
-                        {% if not can_change %}disabled title="{{ 'hq.facility_change_locked'|trans }}"{% endif %}
-                        class="btn btn-outline btn--sm btn--warning"
-                        aria-label="{{ 'hq.downgrade_btn'|trans }}">
-                    {{ 'hq.downgrade_btn'|trans }}
+                        data-cost="{{ upgrade_cost }}"
+                        data-cost-original="{{ upgrade_cost }}"
+                        data-duration="{{ duration_hours }}"
+                        {% if not can_change %}disabled title="{{ 'hq.facility_change_locked'|trans }}"
+                        {% elseif upgrade_blocked %}disabled title="{{ 'financial_crisis.upgrade_blocked'|trans }}"
+                        {% elseif team.gold < upgrade_cost %}disabled title="{{ 'hq.insufficient_gold'|trans }}"{% endif %}
+                        class="btn btn-outline btn--sm"
+                        aria-label="{{ 'hq.upgrade_btn'|trans }}">
+                    {{ 'hq.upgrade_btn'|trans }}
                 </button>
             {% endif %}
-            <button type="button"
-                    data-action="click->hq#upgrade"
-                    data-facility="{{ key }}"
-                    data-cost="{{ upgrade_cost }}"
-                    data-cost-original="{{ upgrade_cost }}"
-                    {% if not can_change %}disabled title="{{ 'hq.facility_change_locked'|trans }}"
-                    {% elseif upgrade_blocked %}disabled title="{{ 'financial_crisis.upgrade_blocked'|trans }}"
-                    {% elseif team.gold < upgrade_cost %}disabled title="{{ 'hq.insufficient_gold'|trans }}"{% endif %}
-                    class="btn btn-outline btn--sm"
-                    aria-label="{{ 'hq.upgrade_btn'|trans }}">
-                {{ 'hq.upgrade_btn'|trans }}
-            </button>
         </div>
     </div>
 </div>

--- a/templates/components/hq/facility_panel/_arena.html.twig
+++ b/templates/components/hq/facility_panel/_arena.html.twig
@@ -11,22 +11,37 @@
                 <h3 class="arena-panel__title">{{ 'arena.status_title'|trans }}</h3>
                 <div class="stat-grid">
                     <div class="arena-stat-card">
+                        <div class="arena-stat-card__icon-wrapper">
+                            <span class="arena-stat-card__icon" aria-hidden="true">🏟️</span>
+                        </div>
                         <span class="arena-stat-card__label">{{ 'arena.level'|trans }}</span>
                         <span class="arena-stat-card__value">{{ status.arena_level }}</span>
                     </div>
                     <div class="arena-stat-card">
+                        <div class="arena-stat-card__icon-wrapper">
+                            <span class="arena-stat-card__icon" aria-hidden="true">🪑</span>
+                        </div>
                         <span class="arena-stat-card__label">{{ 'arena.capacity'|trans }}</span>
                         <span class="arena-stat-card__value">{{ status.seating_capacity }}</span>
                     </div>
                     <div class="arena-stat-card">
+                        <div class="arena-stat-card__icon-wrapper">
+                            <span class="arena-stat-card__icon" aria-hidden="true">🪙</span>
+                        </div>
                         <span class="arena-stat-card__label">{{ 'arena.ticket_price'|trans }}</span>
-                        <span class="arena-stat-card__value">🪙 {{ status.ticket_price }}</span>
+                        <span class="arena-stat-card__value">{{ status.ticket_price }}</span>
                     </div>
                     <div class="arena-stat-card">
+                        <div class="arena-stat-card__icon-wrapper">
+                            <span class="arena-stat-card__icon" aria-hidden="true">📣</span>
+                        </div>
                         <span class="arena-stat-card__label">{{ 'arena.fan_base'|trans }}</span>
                         <span class="arena-stat-card__value">{{ status.fan_base }}</span>
                     </div>
                     <div class="arena-stat-card">
+                        <div class="arena-stat-card__icon-wrapper">
+                            <span class="arena-stat-card__icon" aria-hidden="true">📊</span>
+                        </div>
                         <span class="arena-stat-card__label">{{ 'arena.show_up_rate'|trans }}</span>
                         <span class="arena-stat-card__value">{{ (status.show_up_rate * 100)|number_format(0) }}%</span>
                     </div>
@@ -41,13 +56,27 @@
             </div>
 
             {% if status.next_home_match %}
-            <div class="game-panel">
+            <div class="game-panel arena-match-panel">
                 <h3 class="arena-panel__title">{{ 'arena.next_home_match'|trans }}</h3>
-                <p class="arena-match-lead">{{ 'arena.next_match_home'|trans({'%opponent%': status.next_home_match.opponent}) }}</p>
-                <p class="arena-match-date">{{ status.next_home_match.scheduled_at|date('d.m.Y H:i') }}</p>
-                {% if status.projected_attendance is not null %}
-                <p class="arena-projected-revenue">{{ 'arena.projected_revenue'|trans }}: 🪙 {{ status.projected_revenue }}</p>
-                {% endif %}
+                <div class="arena-match-card">
+                    <div class="arena-match-card__header">
+                        <span class="arena-match-card__badge">🏠 {{ 'arena.home_fans'|trans }}</span>
+                        <span class="arena-match-card__date">📅 {{ status.next_home_match.scheduled_at|date('d.m.Y H:i') }}</span>
+                    </div>
+                    <div class="arena-match-card__body">
+                        <div class="arena-match-card__vs-wrapper">
+                            <span class="arena-match-card__team-name">{{ team.name }}</span>
+                            <span class="arena-match-card__vs">VS</span>
+                            <span class="arena-match-card__opponent">{{ status.next_home_match.opponent }}</span>
+                        </div>
+                    </div>
+                    {% if status.projected_revenue is not null %}
+                        <div class="arena-match-card__footer">
+                            <span class="arena-match-card__projected-label">{{ 'arena.projected_revenue'|trans }}:</span>
+                            <span class="arena-match-card__projected-value">🪙 {{ status.projected_revenue|number_format(0, '.', ' ') }}</span>
+                        </div>
+                    {% endif %}
+                </div>
             </div>
             {% endif %}
 
@@ -81,15 +110,17 @@
             </div>
         </div>
 
-        <div class="game-panel">
-            <h3 class="hero-panel__title hero-panel__title--tight">{{ 'arena.how_it_works'|trans }}</h3>
-            <ul class="arena-rules-list">
-                <li>{{ 'arena.rule_fixed_price'|trans({'%price%': status.ticket_price}) }}</li>
-                <li>{{ 'arena.rule_capacity'|trans }}</li>
-                <li>{{ 'arena.rule_attendance'|trans }}</li>
-                <li>{{ 'arena.rule_home_only'|trans }}</li>
-            </ul>
-            <p class="arena-upgrade-hint">{{ 'arena.upgrade_hint'|trans }}</p>
+        <div class="screen-3col__aside">
+            <div class="game-panel">
+                <h3 class="hero-panel__title hero-panel__title--tight">{{ 'arena.how_it_works'|trans }}</h3>
+                <ul class="arena-rules-list">
+                    <li>{{ 'arena.rule_fixed_price'|trans({'%price%': status.ticket_price}) }}</li>
+                    <li>{{ 'arena.rule_capacity'|trans }}</li>
+                    <li>{{ 'arena.rule_attendance'|trans }}</li>
+                    <li>{{ 'arena.rule_home_only'|trans }}</li>
+                </ul>
+                <p class="arena-upgrade-hint">{{ 'arena.upgrade_hint'|trans }}</p>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/components/hq/facility_panel/_summoning.html.twig
+++ b/templates/components/hq/facility_panel/_summoning.html.twig
@@ -67,7 +67,7 @@
                             {% if status.available %}
                                 🌀 {{ 'summoning.summon_junior'|trans }}
                             {% else %}
-                                {{ status.reason ?: 'summoning.unavailable'|trans }}
+                                {{ status.reason ? status.reason|trans(status.reason_parameters|default([])) : 'summoning.unavailable'|trans }}
                             {% endif %}
                         </button>
                     </div>

--- a/templates/components/layout/sidebar.html.twig
+++ b/templates/components/layout/sidebar.html.twig
@@ -13,8 +13,7 @@
 
         <div class="game-sidebar__section-label">{{ 'sidebar.section_overview'|trans }}</div>
         {% set overview_links = [
-            { route: 'app_dashboard', emoji: '📊', label: 'nav.dashboard', active_check: 'exact' },
-            { route: 'app_calendar', emoji: '📅', label: 'nav.calendar', active_check: 'exact' }
+            { route: 'app_dashboard', emoji: '📊', label: 'nav.dashboard', active_check: 'exact' }
         ] %}
         {% for link in overview_links %}
             {% set is_active = route == link.route %}
@@ -24,8 +23,6 @@
         <div class="game-sidebar__section-label">{{ 'sidebar.section_team'|trans }}</div>
         {% set team_links = [
             { route: 'app_heroes', emoji: '👥', label: 'nav.team', active_check: 'starts_with' },
-            { route: 'app_team_chronicle', emoji: '📜', label: 'nav.chronicle', active_check: 'exact' },
-            { route: 'app_graveyard', emoji: '🪦', label: 'nav.graveyard', active_check: 'exact' },
             { route: 'app_hq', emoji: '🏰', label: 'nav.hq', active_check: 'exact' },
             { route: 'app_formation', emoji: '🛡️', label: 'nav.formation', active_check: 'exact' }
         ] %}
@@ -46,10 +43,21 @@
         <div class="game-sidebar__section-label">{{ 'sidebar.section_social'|trans }}</div>
         {% set social_links = [
             { route: 'app_marketplace', emoji: '⚖️', label: 'nav.marketplace', active_check: 'exact' },
-            { route: 'app_finance', emoji: '📒', label: 'nav.finance', active_check: 'exact' },
             { route: 'app_community', emoji: '💬', label: 'nav.community', active_check: 'starts_with' }
         ] %}
         {% for link in social_links %}
+            {% set is_active = (link.active_check == 'exact' and route == link.route) or (link.active_check == 'starts_with' and route starts with link.route) %}
+            {% include 'components/layout/sidebar_link.html.twig' with { route: link.route, emoji: link.emoji, label: link.label, is_active: is_active } %}
+        {% endfor %}
+
+        <div class="game-sidebar__section-label">{{ 'sidebar.section_archive'|trans }}</div>
+        {% set archive_links = [
+            { route: 'app_team_chronicle', emoji: '📜', label: 'nav.chronicle', active_check: 'exact' },
+            { route: 'app_finance', emoji: '📒', label: 'nav.finance', active_check: 'exact' },
+            { route: 'app_graveyard', emoji: '🪦', label: 'nav.graveyard', active_check: 'exact' },
+            { route: 'app_calendar', emoji: '📅', label: 'nav.calendar', active_check: 'exact' }
+        ] %}
+        {% for link in archive_links %}
             {% set is_active = (link.active_check == 'exact' and route == link.route) or (link.active_check == 'starts_with' and route starts with link.route) %}
             {% include 'components/layout/sidebar_link.html.twig' with { route: link.route, emoji: link.emoji, label: link.label, is_active: is_active } %}
         {% endfor %}

--- a/templates/hq/index.html.twig
+++ b/templates/hq/index.html.twig
@@ -75,7 +75,7 @@
         {% endif %}
 
         <div class="alert alert-info alert--spaced" role="status">
-            <div style="display: flex; justify-content: space-between; align-items: center; width: 100%; gap: 1rem;">
+            <div class="hq-upgrade-banner-content">
                 <div>
                     {{ 'hq.facility_change_in_progress'|trans({
                         '%facility%': ('hq.facilities_list.' ~ hq.upgradingFacility.type.value ~ '.name')|trans,
@@ -91,8 +91,7 @@
                             data-action="click->hq#cancelUpgrade"
                             data-facility="{{ hq.upgradingFacility.type.value }}"
                             data-cost="{{ upgrade_cost }}"
-                            class="btn btn-outline btn--sm btn--danger"
-                            style="flex-shrink: 0;"
+                            class="btn btn-outline btn--sm btn--danger btn--no-shrink"
                             aria-label="{{ 'hq.cancel_upgrade_btn'|trans }}">
                         {{ 'hq.cancel_upgrade_btn'|trans }}
                     </button>

--- a/templates/hq/index.html.twig
+++ b/templates/hq/index.html.twig
@@ -13,6 +13,11 @@
      data-hq-success-downgrade-value="{{ 'js_flash.hq.success_downgrade'|trans }}"
      data-hq-title-downgrade-value="{{ 'hq.downgrade_btn'|trans }}"
      data-hq-confirm-downgrade-value="{{ 'hq.confirm_downgrade'|trans }}"
+     data-hq-title-upgrade-value="{{ 'hq.upgrade_btn'|trans }}"
+     data-hq-confirm-upgrade-value="{{ 'hq.confirm_upgrade'|trans }}"
+     data-hq-title-cancel-upgrade-value="{{ 'hq.cancel_upgrade_btn'|trans }}"
+     data-hq-confirm-cancel-upgrade-value="{{ 'hq.confirm_cancel_upgrade'|trans }}"
+     data-hq-success-cancel-upgrade-value="{{ 'hq.success_cancel_upgrade'|trans }}"
      data-hq-text-saving-value="{{ 'js_flash.hq.saving'|trans }}"
      data-hq-error-adaptation-value="{{ 'js_flash.hq.failed_optimize'|trans }}"
      data-hq-success-adaptation-value="{{ 'js_flash.hq.success_optimize'|trans }}"
@@ -51,14 +56,48 @@
     {% include 'components/dashboard/financial_crisis_banner.html.twig' with { team: team } %}
 
     {% if hq and hq.upgradingFacility %}
+        {% set offset = hq.upgradeCompletedAt ? hq.upgradeCompletedAt|date('Z') : 0 %}
+        {% set actual_completed_local = hq.upgradeCompletedAt ? hq.upgradeCompletedAt|date_modify('+' ~ offset ~ ' seconds') : null %}
+        {% set is_midnight = actual_completed_local ? actual_completed_local|date('H:i') == '00:00' : false %}
+        {% set actual_completed_date = actual_completed_local ? (is_midnight ? actual_completed_local : actual_completed_local|date_modify('+1 day')) : null %}
+        
+        {% set can_cancel_banner = false %}
+        {% if hq.facilityOperation and hq.facilityOperation.value == 'upgrade' and hq.upgradeCompletedAt %}
+            {% set target_level = hq.upgradingFacility.level + 1 %}
+            {% set speed = team.kingdom.gameSpeed %}
+            {% set duration_seconds = speed > 0 ? ((target_level * 24 * 3600) / speed)|round : (target_level * 24 * 3600) %}
+            {% set completed_timestamp = hq.upgradeCompletedAt|date('U') + hq.upgradeCompletedAt|date('Z') %}
+            {% set started_timestamp = completed_timestamp - duration_seconds %}
+            {% set current_timestamp = 'now'|date('U') %}
+            {% if current_timestamp - started_timestamp >= 0 and current_timestamp - started_timestamp < 3600 %}
+                {% set can_cancel_banner = true %}
+            {% endif %}
+        {% endif %}
+
         <div class="alert alert-info alert--spaced" role="status">
-            {{ 'hq.facility_change_in_progress'|trans({
-                '%facility%': ('hq.facilities_list.' ~ hq.upgradingFacility.type.value ~ '.name')|trans,
-                '%operation%': hq.facilityOperation and hq.facilityOperation.value == 'downgrade'
-                    ? ('hq.operation_downgrade'|trans)
-                    : ('hq.operation_upgrade'|trans),
-                '%completed_at%': hq.upgradeCompletedAt ? hq.upgradeCompletedAt|date('d.m.Y H:i') : '—'
-            }) }}
+            <div style="display: flex; justify-content: space-between; align-items: center; width: 100%; gap: 1rem;">
+                <div>
+                    {{ 'hq.facility_change_in_progress'|trans({
+                        '%facility%': ('hq.facilities_list.' ~ hq.upgradingFacility.type.value ~ '.name')|trans,
+                        '%operation%': hq.facilityOperation and hq.facilityOperation.value == 'downgrade'
+                            ? ('hq.operation_downgrade'|trans)
+                            : ('hq.operation_upgrade'|trans),
+                        '%completed_at%': actual_completed_date ? actual_completed_date|date('d.m.Y 00:00') : '—'
+                    }) }}
+                </div>
+                {% if can_cancel_banner %}
+                    {% set upgrade_cost = hq_upgrade_cost(hq.upgradingFacility.type, hq.upgradingFacility.level, hq.computedTotalLevel) %}
+                    <button type="button"
+                            data-action="click->hq#cancelUpgrade"
+                            data-facility="{{ hq.upgradingFacility.type.value }}"
+                            data-cost="{{ upgrade_cost }}"
+                            class="btn btn-outline btn--sm btn--danger"
+                            style="flex-shrink: 0;"
+                            aria-label="{{ 'hq.cancel_upgrade_btn'|trans }}">
+                        {{ 'hq.cancel_upgrade_btn'|trans }}
+                    </button>
+                {% endif %}
+            </div>
         </div>
     {% endif %}
 

--- a/templates/layouts/game.html.twig
+++ b/templates/layouts/game.html.twig
@@ -24,6 +24,7 @@
              'type_hero_dismissal_compensation': 'finance.type_hero_dismissal_compensation'|trans,
              'type_trainer_dismissal_compensation': 'finance.type_trainer_dismissal_compensation'|trans,
              'type_hq_downgrade_refund': 'finance.type_hq_downgrade_refund'|trans,
+             'type_hq_upgrade_refund': 'finance.type_hq_upgrade_refund'|trans,
              'type_kingdom_reward': 'finance.type_kingdom_reward'|trans,
              'error_fetch': 'finance.error_fetch'|trans,
              'text_loading': 'js_flash.common.text_loading'|trans

--- a/tests/Service/Headquarters/HeadquartersServiceTest.php
+++ b/tests/Service/Headquarters/HeadquartersServiceTest.php
@@ -12,6 +12,7 @@ use App\Repository\Headquarters\HeadquartersRepository;
 use App\Service\Economy\EconomyService;
 use App\Service\Economy\FinancialCrisisService;
 use App\Service\Headquarters\HeadquartersService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\AbstractQuery;
@@ -29,6 +30,8 @@ class HeadquartersServiceTest extends TestCase
     private $financialCrisisServiceMock;
     /** @var \PHPUnit\Framework\MockObject\MockObject&\App\Service\Economy\RoyalTreasuryService */
     private $royalTreasuryServiceMock;
+    /** @var \PHPUnit\Framework\MockObject\MockObject&\App\Service\TeamChronicle\TeamChronicleService */
+    private $teamChronicleServiceMock;
     /** @var \PHPUnit\Framework\MockObject\MockObject&\Doctrine\ORM\EntityManagerInterface */
     private $entityManagerMock;
     private HeadquartersService $service;
@@ -39,6 +42,7 @@ class HeadquartersServiceTest extends TestCase
         $this->economyServiceMock = $this->createMock(EconomyService::class);
         $this->financialCrisisServiceMock = $this->createMock(FinancialCrisisService::class);
         $this->royalTreasuryServiceMock = $this->createMock(\App\Service\Economy\RoyalTreasuryService::class);
+        $this->teamChronicleServiceMock = $this->createMock(TeamChronicleService::class);
         $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
 
         $this->service = new HeadquartersService(
@@ -46,6 +50,7 @@ class HeadquartersServiceTest extends TestCase
             $this->economyServiceMock,
             $this->financialCrisisServiceMock,
             $this->royalTreasuryServiceMock,
+            $this->teamChronicleServiceMock,
             $this->entityManagerMock
         );
     }

--- a/tests/Service/League/LeagueMatchResolutionServiceTest.php
+++ b/tests/Service/League/LeagueMatchResolutionServiceTest.php
@@ -22,6 +22,7 @@ use App\Service\League\LeagueStandingService;
 use App\Service\Team\FanClubService;
 use App\Service\Team\TeamMoraleReputationService;
 use App\Service\Team\TeamRosterService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use App\ValueObject\Combat\MatchOutcome;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -44,6 +45,8 @@ class LeagueMatchResolutionServiceTest extends TestCase
     private $fanClubService;
     /** @var \PHPUnit\Framework\MockObject\MockObject&TeamMoraleReputationService */
     private $teamMoraleReputationService;
+    /** @var \PHPUnit\Framework\MockObject\MockObject&TeamChronicleService */
+    private $teamChronicleService;
     /** @var \PHPUnit\Framework\MockObject\MockObject&EntityManagerInterface */
     private $em;
     private LeagueMatchResolutionService $service;
@@ -57,6 +60,7 @@ class LeagueMatchResolutionServiceTest extends TestCase
         $this->fixtureCompletionService = $this->createMock(LeagueFixtureCompletionService::class);
         $this->fanClubService = $this->createMock(FanClubService::class);
         $this->teamMoraleReputationService = $this->createMock(TeamMoraleReputationService::class);
+        $this->teamChronicleService = $this->createMock(TeamChronicleService::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
 
         $this->service = new LeagueMatchResolutionService(
@@ -68,6 +72,7 @@ class LeagueMatchResolutionServiceTest extends TestCase
             $this->fixtureCompletionService,
             $this->fanClubService,
             $this->teamMoraleReputationService,
+            $this->teamChronicleService,
             $this->em,
         );
     }
@@ -182,6 +187,7 @@ class LeagueMatchResolutionServiceTest extends TestCase
             $this->fixtureCompletionService,
             $this->fanClubService,
             $this->teamMoraleReputationService,
+            $this->teamChronicleService,
             $this->em,
         );
         $partial->expects($this->once())

--- a/tests/Service/Training/TrainingServiceTest.php
+++ b/tests/Service/Training/TrainingServiceTest.php
@@ -20,6 +20,7 @@ use App\Repository\Hero\HeroRepository;
 use App\Service\Config\RaceConfig;
 use App\Exception\UserFacingException;
 use App\Service\Training\TrainingService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -33,6 +34,8 @@ class TrainingServiceTest extends TestCase
     private $hqRepositoryMock;
     /** @var \PHPUnit\Framework\MockObject\MockObject&RaceConfig */
     private $raceConfigMock;
+    /** @var \PHPUnit\Framework\MockObject\MockObject&TeamChronicleService */
+    private $teamChronicleServiceMock;
     /** @var \PHPUnit\Framework\MockObject\MockObject&EntityManagerInterface */
     private $entityManagerMock;
     private TrainingService $trainingService;
@@ -42,12 +45,14 @@ class TrainingServiceTest extends TestCase
         $this->heroRepositoryMock = $this->createMock(HeroRepository::class);
         $this->hqRepositoryMock = $this->createMock(HeadquartersRepository::class);
         $this->raceConfigMock = $this->createMock(RaceConfig::class);
+        $this->teamChronicleServiceMock = $this->createMock(TeamChronicleService::class);
         $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
 
         $this->trainingService = new TrainingService(
             $this->heroRepositoryMock,
             $this->hqRepositoryMock,
             $this->raceConfigMock,
+            $this->teamChronicleServiceMock,
             $this->entityManagerMock
         );
     }

--- a/translations/messages.cs.yaml
+++ b/translations/messages.cs.yaml
@@ -225,6 +225,9 @@ error:
   hq_facility_min_level: Zařízení je již na minimální úrovni.
   hq_race_optimization_locked: Uzpůsobení arény je momentálně uzamčeno.
   hq_invalid_race: 'Neplatná rasa: %race%.'
+  hq_no_active_upgrade: Neprobíhá žádné aktivní vylepšování zařízení.
+  hq_cannot_cancel_downgrade: Nelze zrušit snížení úrovně zařízení.
+  hq_cancel_time_expired: Lhůta pro zrušení tohoto vylepšení vypršela.
   item_cannot_equip: Vystavené nebo nedostupné předměty nelze vybavit.
   item_wrong_team: Předmět nepatří ke stejnému týmu jako hrdina.
   item_slot_mismatch: 'Typ slotu předmětu "%item_slot%" nelze vybavit do slotu "%slot%".'

--- a/translations/messages.cs.yaml
+++ b/translations/messages.cs.yaml
@@ -25,7 +25,7 @@ nav:
   economy: Ekonomika
   settings: Nastavení
   toggle_menu: Zobrazit/skrýt menu
-  finance: Ekonomický přehled
+  finance: Finanční deník
   community: Komunita
   mail: Hráčská pošta
   notifications: Notifikace
@@ -403,6 +403,16 @@ activity:
   trainer_purchased: 'Trenér %trainer% (%race%) byl zakoupen na tržišti od týmu %seller% za %price% zlata.'
   trainer_sold: 'Trenér %trainer% (%race%) byl prodán na tržišti týmu %buyer% za %price% zlata.'
   team_renamed: 'Tým byl přejmenován z %old_name% na %new_name%.'
+  battle_win: 'Výhra %score% proti týmu %opponent%.'
+  battle_loss: 'Prohra %score% proti týmu %opponent%.'
+  battle_draw: 'Remíza %score% proti týmu %opponent%.'
+  training_completed:
+    attribute: 'Hrdina %hero% dokončil trénink pod vedením trenéra %trainer% (vlastnost %attribute%, %gain% k základu).'
+    magic: 'Hrdina %hero% dokončil trénink pod vedením trenéra %trainer% (kapacita magie, %gain% slotů).'
+    form: 'Hrdina %hero% dokončil trénink pod vedením trenéra %trainer% (kondice a zotavení, %gain% k formě).'
+  facility_upgraded: 'Budova %facility% byla vylepšena na úroveň %level%.'
+  facility_downgraded: 'Budova %facility% byla snížena na úroveň %level%.'
+  race_optimization_changed: 'Uzpůsobení domácí arény bylo změněno na: %race%.'
   season_status:
     promoted: postup
     relegated: sestup
@@ -430,6 +440,9 @@ activity:
     trainer_purchased: Nákup trenéra
     trainer_sold: Prodej trenéra
     team_renamed: Přejmenování týmu
+    facility_upgraded: Vylepšení budovy
+    facility_downgraded: Snížení budovy
+    race_optimization_changed: Uzpůsobení arény
 
 financial_crisis:
   title_warning: Finanční varování
@@ -478,6 +491,7 @@ sidebar:
   section_team: Tým a základna
   section_competition: Soutěž
   section_social: Obchod a komunita
+  section_archive: Klubový archiv
   future_content: Budoucí obsah
   lock: Zamčeno
 
@@ -641,7 +655,7 @@ summoning:
   fallen_or_dismissed: Padlý nebo propuštěný
 
 finance:
-  title: Ekonomický přehled týmu
+  title: Finanční deník týmu
   subtitle: Přehled příjmů, výdajů a finančních transakcí vašeho týmu.
   summary_title: Souhrn
   ledger_title: Finanční deník
@@ -687,6 +701,7 @@ finance:
   type_hero_dismissal_compensation: Odstupné za propuštění hrdiny
   type_trainer_dismissal_compensation: Odstupné za propuštění trenéra
   type_hq_downgrade_refund: Vratka za snížení úrovně zařízení
+  type_hq_upgrade_refund: Vratka za zrušení vylepšení budovy
   type_kingdom_reward: Odměna z království
   actor_system: Systém
   actor_active: Aktivní akce
@@ -709,6 +724,10 @@ hq:
   downgrade_btn: Snížit úroveň
   downgrade_refund: Vratka po dokončení
   confirm_downgrade: "Opravdu chcete snížit úroveň tohoto zařízení? Po dokončení obdržíte přibližně %refund% zlata."
+  confirm_upgrade: "Opravdu chcete vylepšit toto zařízení? Bude strženo 🪙 %cost% a vylepšení potrvá %duration% hodin."
+  cancel_upgrade_btn: Zrušit vylepšení
+  confirm_cancel_upgrade: "Opravdu chcete zrušit toto vylepšení? Celá částka 🪙 %cost% vám bude vrácena."
+  success_cancel_upgrade: Vylepšení bylo úspěšně zrušeno a zlato vráceno.
   facility_change_in_progress: "Probíhá %operation% zařízení %facility%. Dokončení: %completed_at%."
   facility_changing_here: "Probíhá %operation% tohoto zařízení."
   facility_change_locked: Jiná změna zařízení právě probíhá nebo je aktivní zámek.
@@ -1190,7 +1209,7 @@ arena:
   col_opponent: Soupeř
   col_attendance: Návštěvnost
   no_revenue_yet: Zatím žádné příjmy z domácích zápasů. Výplata proběhne po odehrání ligového zápasu.
-  view_full_ledger: Zobrazit finanční knihu
+  view_full_ledger: Zobrazit finanční deník
   how_it_works: Jak funguje příjem z arény
   rule_fixed_price: "Pevná cena vstupenky: 🪙 %price% za místo."
   rule_capacity: Kapacita hlediště roste s vylepšením arény v základně.

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -225,6 +225,9 @@ error:
   hq_facility_min_level: Facility is already at minimum level.
   hq_race_optimization_locked: Arena adaptation is currently locked.
   hq_invalid_race: 'Invalid race: %race%.'
+  hq_no_active_upgrade: No active facility upgrade in progress.
+  hq_cannot_cancel_downgrade: Cannot cancel a facility downgrade.
+  hq_cancel_time_expired: The grace period for cancelling this upgrade has expired.
   item_cannot_equip: Listed or unavailable items cannot be equipped.
   item_wrong_team: Item does not belong to the same team as the hero.
   item_slot_mismatch: 'Item slot type "%item_slot%" cannot be equipped in slot "%slot%".'

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -25,7 +25,7 @@ nav:
   economy: Economy
   settings: Settings
   toggle_menu: Toggle menu
-  finance: Team overview
+  finance: Financial Ledger
   community: Community
   mail: Player Mail
   notifications: Notifications
@@ -403,6 +403,16 @@ activity:
   trainer_purchased: 'Trainer %trainer% (%race%) was purchased on the marketplace from %seller% for %price% gold.'
   trainer_sold: 'Trainer %trainer% (%race%) was sold on the marketplace to %buyer% for %price% gold.'
   team_renamed: 'Team was renamed from %old_name% to %new_name%.'
+  battle_win: 'Won %score% against %opponent%.'
+  battle_loss: 'Lost %score% against %opponent%.'
+  battle_draw: 'Drew %score% against %opponent%.'
+  training_completed:
+    attribute: 'Hero %hero% completed training under trainer %trainer% (attribute %attribute%, %gain% to base).'
+    magic: 'Hero %hero% completed training under trainer %trainer% (magic capacity, %gain% slots).'
+    form: 'Hero %hero% completed training under trainer %trainer% (recovery, %gain% to form).'
+  facility_upgraded: 'Facility %facility% was upgraded to level %level%.'
+  facility_downgraded: 'Facility %facility% was downgraded to level %level%.'
+  race_optimization_changed: 'Home arena adaptation was changed to: %race%.'
   season_status:
     promoted: promoted
     relegated: relegated
@@ -430,6 +440,9 @@ activity:
     trainer_purchased: Trainer purchased
     trainer_sold: Trainer sold
     team_renamed: Team renamed
+    facility_upgraded: Facility upgraded
+    facility_downgraded: Facility downgraded
+    race_optimization_changed: Arena adaptation changed
 
 financial_crisis:
   title_warning: Financial Warning
@@ -477,6 +490,7 @@ sidebar:
   section_team: Team & Base
   section_competition: Competition
   section_social: Trade & Community
+  section_archive: Club Archive
   future_content: Future Content
   lock: Lock
 
@@ -642,7 +656,7 @@ summoning:
   fallen_or_dismissed: Fallen or Dismissed
 
 finance:
-  title: Team economic overview
+  title: Team Financial Ledger
   subtitle: Overview of your team's income, expenses, and financial transactions.
   summary_title: Summary
   ledger_title: Financial ledger
@@ -688,6 +702,7 @@ finance:
   type_hero_dismissal_compensation: Hero Dismissal Compensation
   type_trainer_dismissal_compensation: Trainer Dismissal Compensation
   type_hq_downgrade_refund: Facility Downgrade Refund
+  type_hq_upgrade_refund: Facility Upgrade Cancellation Refund
   type_kingdom_reward: Kingdom Reward
   actor_system: System
   actor_active: Active Action
@@ -710,6 +725,10 @@ hq:
   downgrade_btn: Downgrade
   downgrade_refund: Refund on completion
   confirm_downgrade: "Are you sure you want to downgrade this facility? You will receive approximately %refund% gold on completion."
+  confirm_upgrade: "Are you sure you want to upgrade this facility? It will cost 🪙 %cost% and the upgrade will take %duration% hours."
+  cancel_upgrade_btn: Cancel Upgrade
+  confirm_cancel_upgrade: "Are you sure you want to cancel this upgrade? The full amount of 🪙 %cost% will be refunded to you."
+  success_cancel_upgrade: Upgrade cancelled successfully and gold refunded.
   facility_change_in_progress: "%operation% of %facility% in progress. Completion: %completed_at%."
   facility_changing_here: "%operation% of this facility is in progress."
   facility_change_locked: Another facility change is in progress or the downgrade lock is active.


### PR DESCRIPTION
- Add endpoint and service logic to cancel HQ facility upgrades within 1 hour with a full gold refund.
- Integrate Team Chronicle events for facility upgrades/downgrades, race optimization, training completion, and match outcomes.
- Update UI templates, Stimulus controller, and styles to support the upgrade cancellation action.
- Register translation keys for new events in Czech and English.
- Update corresponding unit tests.