### PR TITLE
Simulation update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,10 @@
         "php-cs": "vendor/bin/php-cs-fixer check --diff",
         "php-cs-fix": "vendor/bin/php-cs-fixer fix --diff",
         "test": "vendor/bin/phpunit",
+        "kingdom": "php bin/console app:kingdom:initialize \"Main Kingdom\" --test --start-offset-days=-72",
+        "ticks": "php bin/console app:ticks:run",
+        "messenger": "php bin/console messenger:consume async_high async_medium async_low --limit=6000 -vv",
+        "users": "php bin/console app:user:create-test \"Main Kingdom\" --default",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"

--- a/docs/systems/calendar-system.md
+++ b/docs/systems/calendar-system.md
@@ -12,7 +12,7 @@ The game world operates on automated server ticks executed at scheduled times. T
 
 | Day | Time | Event / Tick | Action Details |
 |:---|:---|:---|:---|
-| **Daily** | 00:00 | **Daily Reset & Maintenance** | Cleanup stale match formations, fan club evolution, expired marketplace listings, completed HQ facility upgrades, hero/trainer aging, and season pre-creation on Monday of Week 11. |
+| **Daily** | 00:00 | **Daily Reset & Maintenance** | Cleanup stale match formations, fan club evolution, expired marketplace listings, completed HQ facility upgrades, hero/trainer aging, and season pre-creation on Monday of Week 11. **NPC Simulation:** runs daily roster maintenance (dismissal of negative-trait heroes, roster recycling, summoning). On Tuesday and Friday, runs NPC marketplace actions (buying/selling). On Tuesday, runs NPC training queue configuration. |
 | **Daily** | 03:30 | **Inactive Registration Cleanup** | Remove team assignments and delete unverified player accounts older than 1 day. |
 | **Daily** | 03:45 | **Inactive Player Cleanup** | Release teams from verified players inactive for 28+ days. |
 | **Daily** | 04:00 | **Fatigue & Form Recovery** | Recovery tick for hero fatigue and form (passive restoration). |
@@ -21,7 +21,7 @@ The game world operates on automated server ticks executed at scheduled times. T
 | **Friday** | 18:00 | **League Match (End-Week)** | Process scheduled end-week league fixtures. **Currently implemented:** home-team arena ticket revenue. **Planned (Phase 5):** combat resolution, match XP, post-match fatigue/form/morale/aging. |
 | **Friday** | 19:00 | **Season Transition** *(Week 11 only)* | Run season resolution service: finalize standings, distribute tier promotion/relegation rewards, execute team transfers (promotions/relegations), initialize the next season. |
 | **Sunday** | 09:30 | **Arena Adaptation** | Apply pending headquarters arena adaptation changes and manage weekly adaptation lock cycles. |
-| **Weekly** | Sun 23:59 | **Weekly Reset** | Reset summoning chamber cooldowns, process HQ maintenance fees, **hero/trainer payroll**, **Royal Treasury distribution**, facility downgrade lock expiry, and weekly financial-crisis checks. |
+| **Weekly** | Sun 23:59 | **Weekly Reset** | Reset summoning chamber cooldowns, process HQ maintenance fees, **hero/trainer payroll**, **Royal Treasury distribution**, facility downgrade lock expiry, and weekly financial-crisis checks. **NPC Simulation:** runs weekly HQ upgrades. |
 
 ---
 

--- a/docs/systems/item-system.md
+++ b/docs/systems/item-system.md
@@ -112,11 +112,25 @@ Gold Cost = (100 - current_durability) × cost_per_point[rarity]
 
 ---
 
+## Merchant Purchase (`ItemService::buyFromMerchant`)
+
+Teams can buy items directly from the in-game merchant via `POST /api/v1/items/buy`.
+
+| Step | Details |
+|------|---------|
+| Gold deduction | `EconomyService::deductGold` (`MarketplacePurchase`, actor `Active`) |
+| Item creation | New `Item` with `owner_team_id = buyer`, `status = Available` |
+| Chronicle | `TeamChronicleService::recordItemPurchased` with `seller = null` (shows as "merchant") |
+| Transaction | `MarketplaceTransaction` with `seller_team_id = null`, `listing_id = null`, `fee_amount = 0` |
+
+---
+
 ## Marketplace Interactions
 
 - Listing an item for sale sets `status = selling` (escrow). The item cannot be equipped or dismantled while listed.
 - Cancelling a listing returns the item to `status = available`.
 - On a successful sale the item is transferred to the buyer's team; `owner_team_id` changes and `equipped_hero_id` is cleared.
+- Chronicle events `item_purchased` (buyer) and `item_sold` (seller) are recorded on buy-now and auction settlement.
 
 See [Marketplace System](marketplace-system.md) for listing, bidding, and transaction details.
 
@@ -130,6 +144,7 @@ See [Marketplace System](marketplace-system.md) for listing, bidding, and transa
 | PUT | `/api/v1/heroes/{heroId}/equipment` | Equip or unequip an item |
 | POST | `/api/v1/items/dismantle` | Dismantle item for Essence |
 | POST | `/api/v1/items/{id}/repair` | Repair durability (costs Gold) |
+| POST | `/api/v1/items/buy` | Purchase item from the merchant |
 
 ---
 

--- a/docs/systems/marketplace-system.md
+++ b/docs/systems/marketplace-system.md
@@ -1,25 +1,107 @@
 # Marketplace System
 
-Reference: [game-summary.md](../game-summary.md#211-marketplace-system)
+Reference: [game-summary.md](../game-summary.md#211-marketplace-system), [MarketplaceService.php](../../src/Service/Marketplace/MarketplaceService.php), [MarketplaceTransaction.php](../../src/Entity/Marketplace/MarketplaceTransaction.php)
 
-Purpose: Document listing lifecycle, auctions, fees, and anti-exploit measures.
+Purpose: Document listing lifecycle, auctions, fees, limit checks, transaction records, and chronicle integration.
 
-Sections to fill:
-- Listing model and states
-- Buy-now vs auction mechanics
-- Fee calculation and settlement
-- Anti-fraud and abuse detection
-- Integration with economy accounting
-- Implementation notes
+---
 
+## Listing Types
 
+| `ListingType` | What is listed | Entity used |
+|:---|:---|:---|
+| `Hero` | A combatant hero | `listing.hero_id` |
+| `Trainer` | A trainer hero | `listing.hero_id` |
+| `Item` | An inventory item | `listing.item_id` |
 
-Summary:
-- Marketplace supports listings for heroes, items, and trainers; transactions are Gold-only. Essence is non-tradeable.
-- Apply kingdom-specific tax rates and maintain transaction logs for disputes/auditing.
+- Listing a hero/trainer sets `hero.status = Selling` (escrow).
+- Listing an item sets `item.status = Selling` (escrow).
+- **Trainers listed for sale:** all items equipped on the trainer are automatically unequipped before the listing is created.
+- Cancelling a listing returns the entity to its previous status (`Available`).
 
-APIs:
-- GET /api/marketplace — search listings
-- POST /api/marketplace/listings — create listing
-- POST /api/marketplace/purchase — purchase flow (atomic)
+---
 
+## Buy-Now Flow (`buyListing`)
+
+1. **Ownership check:** buyer cannot be the seller.
+2. **Roster / trainer limit check:**
+   - If listing type is `Hero`: `countActiveCombatantsByTeam(buyer) >= rosterLimit` → throws `error.marketplace_buy_roster_full`.
+   - If listing type is `Trainer`: `countActiveTrainersByTeam(buyer) >= trainerLimit` → throws `error.marketplace_buy_trainer_limit_reached`.
+3. **Price check:** listing must have a `buyout_price_gold` set.
+4. **Gold check:** buyer must have sufficient gold (including the kingdom tax).
+5. **Atomic settlement:**
+   - Gold deducted from buyer via `EconomyService::deductGold` (`MarketplacePurchase`).
+   - Tax paid to kingdom treasury.
+   - Gold credited to seller via `EconomyService::addGold` (`MarketplaceSale`).
+   - Ownership transferred (`hero.team` or `item.owner_team_id` updated).
+   - `MarketplaceTransaction` persisted with `entity_name` snapshot.
+   - For items: `TeamChronicleService::recordItemPurchased` (buyer) and `recordItemSold` (seller).
+
+---
+
+## Auction / Bid Flow
+
+1. Same **roster / trainer limit checks** as buy-now (at bid time, not at settlement).
+2. Bidder must have sufficient gold (amount is reserved/locked).
+3. Settlement runs during the `marketplace_resolution` tick when the listing expires.
+4. For items: `recordItemPurchased` and `recordItemSold` are called on auction settlement.
+
+---
+
+## Transaction Record (`MarketplaceTransaction`)
+
+Table: `marketplace_transaction` — entity `App\Entity\Marketplace\MarketplaceTransaction`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `buyer_team_id` | FK `Team` (not null) | |
+| `seller_team_id` | FK `Team` (nullable) | `null` for merchant purchases |
+| `listing_id` | FK `MarketplaceListing` (nullable) | `null` for merchant purchases |
+| `entity_name` | `string` (nullable) | Snapshot of the hero/item name at time of sale |
+| `amount` | `int` | Total gold paid by buyer |
+| `fee_amount` | `int` | Tax/fee taken (0 for merchant) |
+| `type` | `TransactionType` | `BuyNow` or `AuctionWin` |
+| `created_at` | `datetime_immutable` | UTC |
+
+- `entity_name` is stored as a snapshot so that the transaction history remains readable even after a hero/item is renamed or deleted.
+- In `getTransactionHistory`, if `entity_name` is `null` (legacy rows before this field existed), the value is resolved live from the linked listing.
+- `seller_name` in the API response falls back to the translated `marketplace.merchant` key when `seller_team_id` is `null`.
+
+---
+
+## Merchant Purchases (`ItemService::buyFromMerchant`)
+
+When a team buys an item from the in-game merchant (not from another player):
+
+- Gold is deducted via `EconomyService::deductGold` (`MarketplacePurchase`, actor `Active`).
+- A `MarketplaceTransaction` is created with `seller_team_id = null`, `listing_id = null`, `fee_amount = 0`.
+- `TeamChronicleService::recordItemPurchased` is called with `seller = null` (displays as "merchant").
+
+---
+
+## Fee / Tax Calculation
+
+Tax rates are kingdom-specific and configured in `kingdom.marketplace_tax_rate`. The fee is deducted from the settlement amount before crediting the seller.
+
+---
+
+## APIs
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v1/marketplace` | Search active listings (filterable) |
+| POST | `/api/v1/marketplace/listings` | Create listing (hero / trainer / item) |
+| DELETE | `/api/v1/marketplace/listings/{id}` | Cancel own listing |
+| POST | `/api/v1/marketplace/listings/{id}/buy` | Buy-now purchase |
+| POST | `/api/v1/marketplace/listings/{id}/bid` | Place auction bid |
+| GET | `/api/v1/marketplace/transactions` | Transaction history for the active team |
+
+---
+
+## Related Systems
+
+- [Team Chronicle System](team-chronicle-system.md) — `item_purchased` / `item_sold` events
+- [Item System](item-system.md) — merchant purchase flow, item status lifecycle
+- [Economy System](economy-system.md) — gold deduction / credit (`EconomyService`)
+- [NPC Simulation System](npc-simulation-system.md) — NPC buying and selling behaviour
+- [Headquarters System](headquarters-system.md) — roster and trainer limits

--- a/docs/systems/npc-simulation-system.md
+++ b/docs/systems/npc-simulation-system.md
@@ -1,0 +1,83 @@
+# NPC Simulation System
+
+Reference: [NpcSimulationService.php](../../src/Service/Team/NpcSimulationService.php), [calendar-system.md](calendar-system.md), [team-system.md](team-system.md)
+
+Purpose: Document autonomous behaviors of NPC teams including tactics, training, economy, and scheduler integration.
+
+---
+
+## 1. Economic Archetypes (Roles)
+
+Every NPC team is assigned an archetype based on a deterministic modulo calculation of its database ID: `team_id % 4`. This role dictates priorities for facility upgrades and marketplace activity:
+
+| Archetype | Upgrade Priority | Marketplace Buying Focus | Marketplace Selling Focus |
+|:---|:---|:---|:---|
+| **`mercenary_academy`** | Training -> Summoning -> Barracks | Combat heroes (prefer Orc/Dwarf/Human) | Combat heroes |
+| **`veteran_guild`** | Training -> Treasury -> Medical | Trainers | Trainers |
+| **`royal_collector`** | Arena -> Library -> Summoning | Epic/Legendary/Mythic gear, high-level heroes/trainers | Generic |
+| **`scavenger_clan`** | Treasury -> Medical -> Training | Cheap items (< 150 gold) | Generic |
+
+---
+
+## 2. Match Tactics Simulation
+
+Tactics simulation runs automatically for both teams during the `league_match` tick (prior to match resolution).
+- **Lineup Selection:** Evaluates available heroes for a 3-3 formation. Scores front-row performance (based on STR + KON) and back-row performance (based on INT + SPD + DEX).
+- **Form & Fatigue Adaptation:** Readiness is penalized if fatigue > 50 (50% penalty) or form < 40 (40% penalty).
+- **Trait-Aware Scoring:** Adjusts candidates' scores based on traits (e.g. `Berserker` or `BattleHardened` boost front-row score by +20%, `Glasscannon` boosts back-row score by +20% and penalizes front-row placement, and purely negative traits like `Volatile` penalize both).
+- **Auto-Equip:** NPC teams automatically scan their unequipped inventory and equip the best gear matching the active lineup's preferred weapon and armor masteries.
+
+---
+
+## 3. Training Simulation
+
+Training setups for NPC teams are simulated on **Tuesday 00:00:00 (during Daily Reset)**, exactly 12 hours before the training lock begins (Tuesday 12:00:00).
+- **Trainer Promotion:** Promotes the oldest and highest-level eligible combatants to fill empty trainer slots (excluding purely negative-trait heroes unless desperate).
+- **Trainer Focus Config:** Configures trainer specializations (training type and target attributes) matching the team's economic role.
+- **Trainee Allocation:** Assigns combatants to trainers up to their slot limits, prioritizing those with the `QuickLearner` trait first.
+- **Fairness Guarantee:** Because this runs before the lock starts, a player taking over an NPC team mid-week inherits a fully configured and active training setup instead of an empty or outdated queue.
+
+---
+
+## 4. Roster & Economy Simulation
+
+To mimic realistic player progression and preserve a stable NPC budget, non-tactical decisions are split between daily resets, twice-weekly marketplace ticks, and weekly resets.
+
+### Daily Actions (Daily Reset - 00:00:00)
+- **Proactive Dismissal:** Finds and dismisses non-trainer, low-level heroes carrying purely negative traits (`Slacker`, `Volatile`, `Fragile`, `GlassJaw`) to prevent them from degrading team performance.
+- **Roster Recycling:** If the roster is full and at least one hero is listed for sale, dismisses the worst available combatant to make room for a new summon.
+- **Summoning:** Summons a new hero if the weekly cycle limit is not reached and gold permits (cooldown cost + 150 safety buffer).
+
+### Twice-Weekly Marketplace Actions (Tuesday & Friday - 00:00:00)
+(`simulateMarketplaceActions` — called from `ProcessKingdomTicksHandler` on Tuesday and Friday at 00:00)
+
+**Selling:** Lists at most 1 unequipped item and 1 surplus hero/trainer per tick.
+- Hero/trainer candidates are sorted by descending sell priority: heroes with negative traits and/or low race compatibility with the team's arena theme are listed first.
+- `veteran_guild` prefers selling trainers; all other roles prefer combatants.
+- Items are selected by the cheapest available unequipped item (to free up inventory).
+
+**Buying:** Evaluates all active listings in the same Kingdom and selects the single highest-scoring listing that fits within the team's budget (safety reserve = 2x weekly maintenance).
+
+Score table (score `0` = not interested; higher score wins):
+
+| Listing type | Archetype condition | Score |
+|:---|:---|---:|
+| Item — Epic/Legendary/Mythic | `royal_collector` | 100 |
+| Item — any rarity | `royal_collector` | 10 |
+| Item — price < 150 gold | `scavenger_clan` | 100 |
+| Item — any price | `scavenger_clan` | 20 |
+| Item — Epic/Rare & price < 300 | other roles | 30 |
+| Hero (compatible race, preferred races*) | `mercenary_academy` | 100 |
+| Hero (compatible race, other races) | `mercenary_academy` | 60 |
+| Hero (compatible race) | `royal_collector` | 80 |
+| Hero (compatible race) | other roles | 20 |
+| Trainer | `veteran_guild` | 100 |
+| Trainer | `royal_collector` | 80 |
+| Trainer | other roles | 20 |
+
+*`mercenary_academy` preferred races: Orc, Dwarf, Human. Heroes of incompatible race (outside team's race pool) always score 0.
+
+### Weekly Actions (Weekly Reset - Sunday 23:59:00)
+(`simulateWeeklyManagementAndEconomy` — called from `ProcessKingdomTicksHandler` at Sunday 23:59)
+
+- **Headquarters Upgrades:** Upgrades a single facility if budget allows (respecting a safety reserve of 2x weekly maintenance). Candidates are sorted first by **archetype priority index** (role-specific facility order from `getFacilityPrioritiesForRole`), then by **current level ascending** (to balance equal-priority facilities). Keeps upgrades balanced: the level difference between the highest and lowest facilities after the upgrade must be ≤ 3.

--- a/docs/systems/summoning-system.md
+++ b/docs/systems/summoning-system.md
@@ -24,6 +24,7 @@ See [team-chronicle-system.md](team-chronicle-system.md).
 Summoning is blocked if `hero_count >= roster_limit`.
 - Base roster limit: **10 heroes**.
 - Scales with Barracks facility level (see [Headquarters System](headquarters-system.md#roster-capacity-formula-barracks)).
+- The check uses `HeroRepository::countActiveCombatantsByTeam` — only **active combatants** (role = `Combatant`, status not in `Dead`/`Retired`) count toward the limit. Trainers and dead heroes are excluded.
 
 ### Cycle Limit
 Each team may only summon a limited number of heroes per **weekly cycle**. The limit resets every Sunday at 23:59 as part of the `weekly_reset` tick.
@@ -72,8 +73,9 @@ The race of a summoned hero is **not freely chosen** by the player. It is drawn 
 2. All 8 races are evaluated against the adapted race using the **relationship matrix** (`config/game/race_relations.yaml`).
 3. Races with a relationship score `>= 50` to the adapted race are included in the pool.
 4. A race always has a self-relationship of `100` and is always included.
-5. If no adaptation is set (`race_optimization = null`), **all 8 races** are in the pool.
-6. One race is drawn uniformly at random from the pool.
+5. **Exception — Genie teams:** When the adapted race is `Genie`, the pool is restricted to `[Genie]` only. This prevents hostile racial pairs that occur when applying the standard compatibility matrix to Genie.
+6. If no adaptation is set (`race_optimization = null`), **all 8 races** are in the pool.
+7. One race is drawn uniformly at random from the pool.
 
 ---
 

--- a/docs/systems/team-chronicle-system.md
+++ b/docs/systems/team-chronicle-system.md
@@ -50,6 +50,8 @@ Rendering uses the **viewer's locale** at display time (`TeamChroniclePresenter`
 | `player_released` | Team returned to NPC pool | See release reasons below |
 | `season_ended` | League season transition rewards applied | `SeasonTransitionService` |
 | `summon_completed` | Hero successfully summoned | `SummoningService` |
+| `item_purchased` | Item bought on marketplace or from merchant | `TeamChronicleService::recordItemPurchased()` |
+| `item_sold` | Item sold on marketplace | `TeamChronicleService::recordItemSold()` |
 
 ### `player_released` reasons (`ChronicleReleaseReason`)
 
@@ -62,9 +64,25 @@ Rendering uses the **viewer's locale** at display time (`TeamChroniclePresenter`
 
 Translation keys: `activity.player_released.{reason}` with `%player%` param.
 
+### `item_purchased` data shape
+
+```json
+{ "item_id": 123, "seller_team_id": 456, "price": 350 }
+```
+
+`seller_team_id` is `null` when purchased from the in-game merchant (`ItemService::buyFromMerchant`). Subject params: `%item%`, `%seller%`, `%price%`.
+
+### `item_sold` data shape
+
+```json
+{ "item_id": 123, "buyer_team_id": 789, "price": 350 }
+```
+
+Subject params: `%item%`, `%buyer%`, `%price%`.
+
 ### Reserved (enum exists; write hooks pending)
 
-`battle_win`, `battle_loss`, `battle_draw`, `hero_levelup`, `hero_died`, `hero_retired`, `training_completed`, `item_purchased`, `item_sold`, `dungeon_completed` — to be wired when combat, XP, marketplace chronicle integration, etc. are implemented.
+`battle_win`, `battle_loss`, `battle_draw`, `hero_levelup`, `hero_died`, `hero_retired`, `training_completed`, `dungeon_completed` — to be wired when combat, XP, etc. are implemented.
 
 ---
 
@@ -86,7 +104,7 @@ Translation keys: `activity.player_released.{reason}` with `%player%` param.
 
 | Class | Responsibility |
 |-------|----------------|
-| `TeamChronicleService` | Create and persist chronicle entries (single write entry point) |
+| `TeamChronicleService` | Create and persist chronicle entries (single write entry point). Depends on `EntityManagerInterface`, `TickClock`, and `UserMessageTranslator`. |
 | `TeamChroniclePresenter` | Load entries, translate messages, attach icons and type labels |
 | `TeamChronicleRepository` | `findRecentByTeam()`, `findByTeamFiltered()` |
 
@@ -133,6 +151,8 @@ Styles: `assets/styles/components/_chronicle.scss`.
 - [Financial Crisis System](financial-crisis-system.md) — `player_released` / bankruptcy
 - [League System](league-system.md) — `season_ended`
 - [Summoning System](summoning-system.md) — `summon_completed` (parallel detail in `TeamSummonHistory` per hero)
+- [Marketplace System](marketplace-system.md) — `item_purchased` / `item_sold` on buy-now and auction settlement
+- [Item System](item-system.md) — `item_purchased` on merchant purchase
 
 ---
 

--- a/docs/systems/team-system.md
+++ b/docs/systems/team-system.md
@@ -34,7 +34,7 @@ Every team in the system, including AI-controlled opponents, is represented by t
 - **Fully staffed**: Each NPC team is created with **10 heroes** and a default formation.
 - **Assigned to a real player on registration**: When a player registers, a random unclaimed NPC team (`user_id IS NULL`) in their Kingdom is assigned to them immediately (`user_id` set, `is_npc` set to false). A `team_chronicle` entry with type `player_joined` is recorded on the team chronicle. If the registration is not verified within 24 hours, a daily maintenance tick (running at 03:30 AM) removes the team assignment, writes `player_released` / `unverified_registration`, and deletes the user.
 - **Inactive player release**: Verified players who do not log in or play for **28 days** have their team released back to the NPC pool (daily tick at 03:45 AM). Chronicle entry: `player_released` / `inactivity`. A warning is sent after **21 days** of inactivity. See [player-inactivity-system.md](player-inactivity-system.md).
-- **AI-controlled gameplay**: NPC matches are resolved by the combat engine automatically; NPC teams do not submit lineup changes unless an AI controller is implemented.
+- **AI-controlled gameplay**: NPC matches are resolved by the combat engine automatically. NPC tactics (lineup, gear, and slot strategies), training setups, summoning, and marketplace activities are autonomously simulated. See [npc-simulation-system.md](npc-simulation-system.md) for full implementation details.
 
 ## Sections to Fill
 

--- a/docs/systems/training-system.md
+++ b/docs/systems/training-system.md
@@ -38,6 +38,7 @@ During the lock period, players cannot configure trainers, assign heroes, or una
 | **Attribute Cap** | A hero cannot train a primary attribute beyond the Trainer's frozen value for that attribute. |
 | **No monetary cost** | Training has no Gold or Essence cost. It is instead balanced by a high fatigue load. |
 | **Trainer aging** | Trainers age during each weekly tick by the same amount a hero would age from a combat death (applies to all races, including Undead). |
+| **Auto-unequip on promotion** | When a combatant is promoted to trainer role (`TrainingService::promoteToTrainer`), all items equipped on that hero are automatically unequipped (set to `Available`). The same unequip step also applies when a trainer is listed for sale on the marketplace. |
 
 ## Hero Creation Age
 

--- a/migrations/Version20260630220000.php
+++ b/migrations/Version20260630220000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260630220000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make seller_team_id and listing_id nullable on marketplace_transaction and add entity_name column';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE marketplace_transaction DROP FOREIGN KEY FK_48741494F26261BF');
+        $this->addSql('ALTER TABLE marketplace_transaction DROP FOREIGN KEY FK_48741494D4619D1A');
+        $this->addSql('ALTER TABLE marketplace_transaction CHANGE seller_team_id seller_team_id INT DEFAULT NULL, CHANGE listing_id listing_id INT DEFAULT NULL, ADD entity_name VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE marketplace_transaction ADD CONSTRAINT FK_48741494F26261BF FOREIGN KEY (seller_team_id) REFERENCES team (id)');
+        $this->addSql('ALTER TABLE marketplace_transaction ADD CONSTRAINT FK_48741494D4619D1A FOREIGN KEY (listing_id) REFERENCES marketplace_listing (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE marketplace_transaction DROP FOREIGN KEY FK_48741494F26261BF');
+        $this->addSql('ALTER TABLE marketplace_transaction DROP FOREIGN KEY FK_48741494D4619D1A');
+        $this->addSql('ALTER TABLE marketplace_transaction CHANGE seller_team_id seller_team_id INT NOT NULL, CHANGE listing_id listing_id INT NOT NULL, DROP entity_name');
+        $this->addSql('ALTER TABLE marketplace_transaction ADD CONSTRAINT FK_48741494F26261BF FOREIGN KEY (seller_team_id) REFERENCES team (id)');
+        $this->addSql('ALTER TABLE marketplace_transaction ADD CONSTRAINT FK_48741494D4619D1A FOREIGN KEY (listing_id) REFERENCES marketplace_listing (id)');
+    }
+}

--- a/src/Entity/Marketplace/MarketplaceTransaction.php
+++ b/src/Entity/Marketplace/MarketplaceTransaction.php
@@ -23,12 +23,15 @@ class MarketplaceTransaction
     private Team $buyerTeam;
 
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(nullable: false)]
-    private Team $sellerTeam;
+    #[ORM\JoinColumn(nullable: true)]
+    private ?Team $sellerTeam = null;
 
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(nullable: false)]
-    private MarketplaceListing $listing;
+    #[ORM\JoinColumn(nullable: true)]
+    private ?MarketplaceListing $listing = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $entityName = null;
 
     #[ORM\Column]
     private int $amount;
@@ -64,26 +67,38 @@ class MarketplaceTransaction
         return $this;
     }
 
-    public function getSellerTeam(): Team
+    public function getSellerTeam(): ?Team
     {
         return $this->sellerTeam;
     }
 
-    public function setSellerTeam(Team $sellerTeam): static
+    public function setSellerTeam(?Team $sellerTeam): static
     {
         $this->sellerTeam = $sellerTeam;
 
         return $this;
     }
 
-    public function getListing(): MarketplaceListing
+    public function getListing(): ?MarketplaceListing
     {
         return $this->listing;
     }
 
-    public function setListing(MarketplaceListing $listing): static
+    public function setListing(?MarketplaceListing $listing): static
     {
         $this->listing = $listing;
+
+        return $this;
+    }
+
+    public function getEntityName(): ?string
+    {
+        return $this->entityName;
+    }
+
+    public function setEntityName(?string $entityName): static
+    {
+        $this->entityName = $entityName;
 
         return $this;
     }

--- a/src/Message/ExecuteSingleTickHandler.php
+++ b/src/Message/ExecuteSingleTickHandler.php
@@ -150,7 +150,6 @@ class ExecuteSingleTickHandler
         switch ($type) {
             case TickType::WeeklyTraining:
                 if (null !== $team) {
-                    $this->npcSimulationService->simulateTraining($kingdom, $scheduledAt, $team);
                     $this->trainingService->processTrainingTick($scheduledAt, $kingdom, $team);
                     $this->processTrainingMastery($team);
                 }
@@ -159,7 +158,7 @@ class ExecuteSingleTickHandler
             case TickType::WeeklyReset:
                 if (null !== $team) {
                     // Team-scoped weekly reset
-                    $this->npcSimulationService->simulateManagementAndEconomy($kingdom, $scheduledAt, $team);
+                    $this->npcSimulationService->simulateWeeklyManagementAndEconomy($kingdom, $scheduledAt, $team);
                     $this->resetWeeklySummons($kingdom, $team);
                     $this->hqService->processMaintenanceTick($kingdom, $team);
                     $this->teamPayrollService->processPayrollTick($kingdom, $team);
@@ -369,6 +368,24 @@ class ExecuteSingleTickHandler
                 if ($scheduledAt->setTime(0, 0, 0) >= $mondayWeek11) {
                     $this->seasonTransitionService->prepareUpcomingSeason($kingdom);
                 }
+            }
+        }
+
+        // Run daily NPC simulation actions
+        if ($team->isNpc()) {
+            $this->npcSimulationService->simulateDailyManagementAndEconomy($kingdom, $scheduledAt, $team);
+
+            // Determine local day of the week to run weekly/twice-weekly tasks
+            $tz = new \DateTimeZone($kingdom->getTimezone());
+            $localTime = $scheduledAt->setTimezone($tz);
+            $localDay = (int) $localTime->format('N');
+
+            if (2 === $localDay || 5 === $localDay) {
+                $this->npcSimulationService->simulateMarketplaceActions($kingdom, $scheduledAt, $team);
+            }
+
+            if (2 === $localDay) {
+                $this->npcSimulationService->simulateTraining($kingdom, $scheduledAt, $team);
             }
         }
     }

--- a/src/Repository/Hero/HeroRepository.php
+++ b/src/Repository/Hero/HeroRepository.php
@@ -69,6 +69,34 @@ class HeroRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    public function countActiveCombatantsByTeam(Team $team): int
+    {
+        return (int) $this->createQueryBuilder('h')
+            ->select('COUNT(h.id)')
+            ->where('h.team = :team')
+            ->andWhere('h.role = :role')
+            ->andWhere('h.status NOT IN (:deadStatuses)')
+            ->setParameter('team', $team)
+            ->setParameter('role', HeroRole::Combatant)
+            ->setParameter('deadStatuses', [HeroStatus::Dead, HeroStatus::Retired])
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countActiveTrainersByTeam(Team $team): int
+    {
+        return (int) $this->createQueryBuilder('h')
+            ->select('COUNT(h.id)')
+            ->where('h.team = :team')
+            ->andWhere('h.role = :role')
+            ->andWhere('h.status NOT IN (:deadStatuses)')
+            ->setParameter('team', $team)
+            ->setParameter('role', HeroRole::Trainer)
+            ->setParameter('deadStatuses', [HeroStatus::Dead, HeroStatus::Retired])
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     /**
      * @return list<Hero>
      */

--- a/src/Service/Item/ItemService.php
+++ b/src/Service/Item/ItemService.php
@@ -6,14 +6,20 @@ namespace App\Service\Item;
 
 use App\Entity\Hero\Hero;
 use App\Entity\Item\Item;
+use App\Entity\Marketplace\MarketplaceTransaction;
 use App\Entity\Team\Team;
+use App\Enum\FinancialRecordActor;
+use App\Enum\FinancialRecordType;
 use App\Enum\ItemCategory;
 use App\Enum\ItemRarity;
 use App\Enum\ItemSlotType;
 use App\Enum\ItemStatus;
 use App\Enum\ItemSubType;
+use App\Enum\TransactionType;
 use App\Exception\UserFacingException;
 use App\Repository\Item\ItemRepository;
+use App\Service\Economy\EconomyService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use App\Service\Translation\UserMessageTranslator;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -46,6 +52,8 @@ class ItemService
         private readonly ItemRepository $itemRepository,
         private readonly EntityManagerInterface $em,
         private readonly UserMessageTranslator $translator,
+        private readonly EconomyService $economyService,
+        private readonly TeamChronicleService $teamChronicleService,
     ) {
     }
 
@@ -469,7 +477,12 @@ class ItemService
         }
 
         // Deduct gold
-        $team->setGold($team->getGold() - $cost);
+        $this->economyService->deductGold(
+            $team,
+            $cost,
+            FinancialRecordType::MarketplacePurchase,
+            FinancialRecordActor::Active
+        );
 
         // Create Item
         $item = new Item();
@@ -485,6 +498,22 @@ class ItemService
         $item->setSubType(isset($template['sub_type']) ? ItemSubType::tryFrom($template['sub_type']) : null);
 
         $this->em->persist($item);
+        $this->em->flush();
+
+        // Record chronicle entry
+        $this->teamChronicleService->recordItemPurchased($team, $item, null, $cost);
+
+        // Record marketplace transaction
+        $transaction = new MarketplaceTransaction();
+        $transaction->setBuyerTeam($team);
+        $transaction->setSellerTeam(null);
+        $transaction->setListing(null);
+        $transaction->setAmount($cost);
+        $transaction->setFeeAmount(0);
+        $transaction->setType(TransactionType::BuyNow);
+        $transaction->setEntityName($item->getName());
+
+        $this->em->persist($transaction);
         $this->em->flush();
 
         return $item;

--- a/src/Service/Kingdom/KingdomInitializationService.php
+++ b/src/Service/Kingdom/KingdomInitializationService.php
@@ -198,14 +198,14 @@ class KingdomInitializationService
 
         $today = new \DateTimeImmutable('today');
         $status = LeagueSeasonStatus::Scheduled;
-        if ($start <= $today && $today <= $end) {
-            $active = (string) ($seasonConfig['status_when_started'] ?? 'active');
-            $status = LeagueSeasonStatus::tryFrom($active) ?? LeagueSeasonStatus::Active;
-        } elseif ($start > $today) {
+        if ($start > $today) {
             $future = (string) ($seasonConfig['status_when_future'] ?? 'scheduled');
             $status = LeagueSeasonStatus::tryFrom($future) ?? LeagueSeasonStatus::Scheduled;
         } else {
-            $status = LeagueSeasonStatus::Completed;
+            // Even if the season end date is in the past, we initialize it as Active
+            // so that catch-up ticks can run and transition it to subsequent seasons correctly.
+            $active = (string) ($seasonConfig['status_when_started'] ?? 'active');
+            $status = LeagueSeasonStatus::tryFrom($active) ?? LeagueSeasonStatus::Active;
         }
 
         $season = new LeagueSeason();
@@ -319,8 +319,13 @@ class KingdomInitializationService
     {
         $count = (int) ($teamConfig['heroes_per_team'] ?? 10);
 
-        // Limit hero races to those with at least neutral (>=50) affinity to the team's race.
-        $compatibleRaces = $this->raceConfig->getCompatibleRaces($teamRace, 50);
+        if (Race::Genie === $teamRace) {
+            // Genie starting roster is restricted to Genie only to prevent hostile pairs among various compatible races.
+            $compatibleRaces = [$teamRace];
+        } else {
+            // Limit hero races to those with at least neutral (>=50) affinity to the team's race.
+            $compatibleRaces = $this->raceConfig->getCompatibleRaces($teamRace, 50);
+        }
 
         $heroes = [];
         for ($i = 0; $i < $count; ++$i) {

--- a/src/Service/Marketplace/MarketplaceService.php
+++ b/src/Service/Marketplace/MarketplaceService.php
@@ -28,10 +28,13 @@ use App\Service\Config\RaceConfig;
 use App\Service\Economy\EconomyService;
 use App\Service\Economy\FinancialCrisisService;
 use App\Service\Economy\RoyalTreasuryService;
+use App\Service\Headquarters\HeadquartersService;
 use App\Service\Hero\HeroRatingCalculator;
 use App\Service\Notification\NotificationHelper;
 use App\Service\Team\TeamChemistryService;
 use App\Service\Team\TeamRosterService;
+use App\Service\Training\TrainingService;
+use App\Service\Translation\UserMessageTranslator;
 use Doctrine\ORM\EntityManagerInterface;
 
 class MarketplaceService
@@ -47,6 +50,9 @@ class MarketplaceService
         private readonly TeamChemistryService $teamChemistryService,
         private readonly HeroRatingCalculator $heroRatingCalculator,
         private readonly RaceConfig $raceConfig,
+        private readonly UserMessageTranslator $translator,
+        private readonly HeadquartersService $hqService,
+        private readonly TrainingService $trainingService,
     ) {
     }
 
@@ -109,6 +115,13 @@ class MarketplaceService
 
             $this->teamRosterService->assertCanRemoveCombatReadyHero($seller, $hero);
 
+            // Unequip all items from the hero before sale
+            $equippedItems = $this->em->getRepository(Item::class)->findBy(['equippedHero' => $hero]);
+            foreach ($equippedItems as $item) {
+                $item->setEquippedHero(null);
+                $item->setEquippedSlot(null);
+            }
+
             // Escrow hero
             $hero->setStatus(HeroStatus::Selling);
             $listing->setHero($hero);
@@ -144,6 +157,13 @@ class MarketplaceService
 
             foreach ($trainer->getTrainees() as $hero) {
                 $trainer->removeTrainee($hero);
+            }
+
+            // Unequip all items from the trainer before sale
+            $equippedItems = $this->em->getRepository(Item::class)->findBy(['equippedHero' => $trainer]);
+            foreach ($equippedItems as $item) {
+                $item->setEquippedHero(null);
+                $item->setEquippedSlot(null);
             }
 
             $trainer->setStatus(HeroStatus::Selling);
@@ -200,6 +220,20 @@ class MarketplaceService
 
         if ($listing->getSellerTeam()->getId() === $buyer->getId()) {
             throw new UserFacingException('error.marketplace_cannot_buy_own');
+        }
+
+        if (ListingType::Hero === $listing->getListingType()) {
+            $rosterLimit = $this->hqService->getRosterLimit($buyer);
+            $combatantCount = $this->em->getRepository(Hero::class)->countActiveCombatantsByTeam($buyer);
+            if ($combatantCount >= $rosterLimit) {
+                throw new UserFacingException('error.marketplace_buy_roster_full');
+            }
+        } elseif (ListingType::Trainer === $listing->getListingType()) {
+            $trainerLimit = $this->trainingService->getTrainerLimit($buyer);
+            $trainerCount = $this->em->getRepository(Hero::class)->countActiveTrainersByTeam($buyer);
+            if ($trainerCount >= $trainerLimit) {
+                throw new UserFacingException('error.marketplace_buy_trainer_limit_reached');
+            }
         }
 
         $buyoutPrice = $listing->getBuyoutPriceGold();
@@ -266,6 +300,17 @@ class MarketplaceService
         $transaction->setAmount($buyoutPrice);
         $transaction->setFeeAmount($tax);
         $transaction->setType(TransactionType::BuyNow);
+
+        $entityName = 'Unknown';
+        if (ListingType::Hero === $listing->getListingType() && null !== $listing->getHero()) {
+            $entityName = $listing->getHero()->getName();
+        } elseif (ListingType::Item === $listing->getListingType() && null !== $listing->getItem()) {
+            $entityName = $listing->getItem()->getName();
+        } elseif (ListingType::Trainer === $listing->getListingType() && null !== $listing->getHero()) {
+            $entityName = $listing->getHero()->getName();
+        }
+        $transaction->setEntityName($entityName);
+
         $this->em->persist($transaction);
 
         // Transfer ownership
@@ -280,6 +325,8 @@ class MarketplaceService
             $item = $listing->getItem();
             $item->setOwnerTeam($buyer);
             $item->setStatus(ItemStatus::Available);
+            $this->teamChronicleService->recordItemPurchased($buyer, $item, $seller, $buyoutPrice);
+            $this->teamChronicleService->recordItemSold($seller, $item, $buyer, $buyoutPrice);
         } elseif (ListingType::Trainer === $listing->getListingType() && null !== $listing->getHero()) {
             $trainer = $listing->getHero();
             $trainer->setTeam($buyer);
@@ -332,6 +379,20 @@ class MarketplaceService
 
         if ($listing->getSellerTeam()->getId() === $bidder->getId()) {
             throw new UserFacingException('error.marketplace_cannot_bid_own');
+        }
+
+        if (ListingType::Hero === $listing->getListingType()) {
+            $rosterLimit = $this->hqService->getRosterLimit($bidder);
+            $combatantCount = $this->em->getRepository(Hero::class)->countActiveCombatantsByTeam($bidder);
+            if ($combatantCount >= $rosterLimit) {
+                throw new UserFacingException('error.marketplace_buy_roster_full');
+            }
+        } elseif (ListingType::Trainer === $listing->getListingType()) {
+            $trainerLimit = $this->trainingService->getTrainerLimit($bidder);
+            $trainerCount = $this->em->getRepository(Hero::class)->countActiveTrainersByTeam($bidder);
+            if ($trainerCount >= $trainerLimit) {
+                throw new UserFacingException('error.marketplace_buy_trainer_limit_reached');
+            }
         }
 
         if ($bidder->getGold() < $bidAmount) {
@@ -485,6 +546,17 @@ class MarketplaceService
                 $transaction->setAmount($winningBidAmount);
                 $transaction->setFeeAmount($tax);
                 $transaction->setType(TransactionType::AuctionWin);
+
+                $entityName = 'Unknown';
+                if (ListingType::Hero === $listing->getListingType() && null !== $listing->getHero()) {
+                    $entityName = $listing->getHero()->getName();
+                } elseif (ListingType::Item === $listing->getListingType() && null !== $listing->getItem()) {
+                    $entityName = $listing->getItem()->getName();
+                } elseif (ListingType::Trainer === $listing->getListingType() && null !== $listing->getHero()) {
+                    $entityName = $listing->getHero()->getName();
+                }
+                $transaction->setEntityName($entityName);
+
                 $this->em->persist($transaction);
 
                 // Transfer ownership
@@ -501,6 +573,8 @@ class MarketplaceService
                     $item = $listing->getItem();
                     $item->setOwnerTeam($winner);
                     $item->setStatus(ItemStatus::Available);
+                    $this->teamChronicleService->recordItemPurchased($winner, $item, $seller, $winningBidAmount);
+                    $this->teamChronicleService->recordItemSold($seller, $item, $winner, $winningBidAmount);
                 } elseif (ListingType::Trainer === $listing->getListingType() && null !== $listing->getHero()) {
                     $trainer = $listing->getHero();
                     $trainer->setTeam($winner);
@@ -862,19 +936,39 @@ class MarketplaceService
         $data = [];
         foreach ($transactions as $tx) {
             $listing = $tx->getListing();
+            $listingId = $listing?->getId();
+            $listingType = $listing?->getListingType()->value ?? ListingType::Item->value;
+
+            $entityName = $tx->getEntityName();
+            if (null === $entityName) {
+                if (null !== $listing) {
+                    if (null !== $listing->getHero()) {
+                        $entityName = $listing->getHero()->getName();
+                    } elseif (ListingType::Item === $listing->getListingType() && null !== $listing->getItem()) {
+                        $entityName = $listing->getItem()->getName();
+                    } else {
+                        $entityName = 'Unknown';
+                    }
+                } else {
+                    $entityName = 'Unknown';
+                }
+            }
+
+            $sellerName = null !== $tx->getSellerTeam()
+                ? $tx->getSellerTeam()->getName()
+                : $this->translator->trans('marketplace.merchant');
 
             $data[] = [
                 'id' => $tx->getId(),
                 'buyer_name' => $tx->getBuyerTeam()->getName(),
-                'seller_name' => $tx->getSellerTeam()->getName(),
+                'seller_name' => $sellerName,
                 'amount' => $tx->getAmount(),
                 'fee_amount' => $tx->getFeeAmount(),
                 'type' => $tx->getType()->value,
                 'created_at' => $tx->getCreatedAt()->format(\DateTimeInterface::ATOM),
-                'listing_id' => $listing->getId(),
-                'listing_type' => $listing->getListingType()->value,
-                'entity_name' => null !== $listing->getHero() ? $listing->getHero()->getName() :
-                    (ListingType::Item === $listing->getListingType() && null !== $listing->getItem() ? $listing->getItem()->getName() : 'Unknown'),
+                'listing_id' => $listingId,
+                'listing_type' => $listingType,
+                'entity_name' => $entityName,
             ];
         }
 

--- a/src/Service/Summoning/SummoningService.php
+++ b/src/Service/Summoning/SummoningService.php
@@ -79,7 +79,7 @@ class SummoningService
         $maxSummons = (int) max(1, round(self::MAX_SUMMONS_PER_CYCLE * (float) $team->getKingdom()->getGameSpeed()));
 
         $rosterLimit = $this->hqService->getRosterLimit($team);
-        $heroCount = $this->em->getRepository(Hero::class)->count(['team' => $team]);
+        $heroCount = $this->em->getRepository(Hero::class)->countActiveCombatantsByTeam($team);
         if ($heroCount >= $rosterLimit) {
             return [
                 'available' => false,
@@ -197,7 +197,7 @@ class SummoningService
     public function summon(Team $team): Hero
     {
         $rosterLimit = $this->hqService->getRosterLimit($team);
-        $heroCount = $this->em->getRepository(Hero::class)->count(['team' => $team]);
+        $heroCount = $this->em->getRepository(Hero::class)->countActiveCombatantsByTeam($team);
         if ($heroCount >= $rosterLimit) {
             throw new UserFacingException('error.summoning_roster_full');
         }

--- a/src/Service/Team/NpcSimulationService.php
+++ b/src/Service/Team/NpcSimulationService.php
@@ -26,6 +26,7 @@ use App\Enum\ListingStatus;
 use App\Enum\ListingType;
 use App\Enum\Race;
 use App\Enum\TrainingType;
+use App\Service\Config\RaceConfig;
 use App\Service\Headquarters\HeadquartersService;
 use App\Service\Hero\HeroDismissalService;
 use App\Service\Hero\HeroRatingCalculator;
@@ -98,6 +99,7 @@ class NpcSimulationService
         private readonly ItemService $itemService,
         private readonly HeroDismissalService $dismissalService,
         private readonly HeroRatingCalculator $heroRatingCalculator,
+        private readonly RaceConfig $raceConfig,
     ) {
     }
 
@@ -209,10 +211,10 @@ class NpcSimulationService
                     if (\in_array($trait, [HeroTrait::Fragile, HeroTrait::GlassJaw], true)) {
                         $frontScore *= 0.80;
                     }
-                    // Volatile: penalize — unstable heroes are suboptimal, prefer bench
-                    if (HeroTrait::Volatile === $trait) {
-                        $frontScore *= 0.90;
-                        $backScore *= 0.90;
+                    // Purely negative trait: heavily penalize so they prefer bench
+                    if ($this->isPurelyNegativeTrait($trait)) {
+                        $frontScore *= 0.10;
+                        $backScore *= 0.10;
                     }
                 }
 
@@ -255,27 +257,6 @@ class NpcSimulationService
                     if ($hero->isTrainer()) {
                         continue;
                     }
-                    $heroId = $hero->getId();
-                    if (null === $heroId) {
-                        continue;
-                    }
-                    if (count($selectedFront) + count($selectedBack) >= 6) {
-                        break;
-                    }
-                    if (!isset($usedHeroIds[$heroId])) {
-                        if (count($selectedFront) < 3) {
-                            $selectedFront[] = $hero;
-                        } else {
-                            $selectedBack[] = $hero;
-                        }
-                        $usedHeroIds[$heroId] = true;
-                    }
-                }
-            }
-
-            // Absolute fallback (including trainers if needed to avoid forfeit)
-            if (count($selectedFront) + count($selectedBack) < 6) {
-                foreach ($heroes as $hero) {
                     $heroId = $hero->getId();
                     if (null === $heroId) {
                         continue;
@@ -421,6 +402,13 @@ class NpcSimulationService
                 $candidate->setRole(HeroRole::Trainer);
                 $trainers[] = $candidate;
 
+                // Unequip all items from the NPC candidate being promoted to trainer
+                $equippedItems = $this->em->getRepository(Item::class)->findBy(['equippedHero' => $candidate]);
+                foreach ($equippedItems as $item) {
+                    $item->setEquippedHero(null);
+                    $item->setEquippedSlot(null);
+                }
+
                 // Remove from trainees list
                 $idx = array_search($candidate, $trainees, true);
                 if (false !== $idx) {
@@ -491,11 +479,14 @@ class NpcSimulationService
     }
 
     /**
-     * Run management and economy simulation: summoning, HQ upgrades, and marketplace buy/sell behavior.
+     * Run daily management and economy simulation: proactive dismissal, roster recycling, and summoning.
      */
-    public function simulateManagementAndEconomy(Kingdom $kingdom, \DateTimeImmutable $now, ?Team $team = null): void
+    public function simulateDailyManagementAndEconomy(Kingdom $kingdom, \DateTimeImmutable $now, ?Team $team = null): void
     {
         if (null !== $team) {
+            if (!$team->isNpc()) {
+                return;
+            }
             $teams = [$team];
         } else {
             $teams = $this->em->getRepository(Team::class)->findBy([
@@ -505,8 +496,6 @@ class NpcSimulationService
         }
 
         foreach ($teams as $team) {
-            $role = $this->getEconomicRole($team);
-
             // Fetch alive heroes
             $aliveHeroes = $this->em->getRepository(Hero::class)->createQueryBuilder('h')
                 ->where('h.team = :team')
@@ -517,6 +506,12 @@ class NpcSimulationService
                 ->getResult();
 
             $heroCount = count($aliveHeroes);
+            $combatantCount = 0;
+            foreach ($aliveHeroes as $h) {
+                if ($h->isCombatant()) {
+                    ++$combatantCount;
+                }
+            }
             $rosterLimit = $this->hqService->getRosterLimit($team);
 
             // Calculate selling count
@@ -531,57 +526,55 @@ class NpcSimulationService
             // Heroes with a purely negative trait are unlikely to sell on the marketplace
             // and degrade team performance. Dismiss them unless they qualify as trainer candidates
             // (high level or age — someone may want them for training despite the trait).
-            if (!($heroCount >= $rosterLimit && $sellingCount >= 1)) {
-                // Only run proactive dismissal when the roster is NOT already in recycle mode
-                foreach ($aliveHeroes as $hero) {
-                    $heroId = $hero->getId();
-                    if (null === $heroId) {
-                        continue;
-                    }
-                    if (HeroStatus::Available !== $hero->getStatus()) {
-                        continue;
-                    }
-                    if ($hero->isTrainer()) {
-                        continue; // Never dismiss active trainers
-                    }
-                    if (!$this->isPurelyNegativeTrait($hero->getTrait())) {
-                        continue; // Only negative-trait heroes
-                    }
+            foreach ($aliveHeroes as $hero) {
+                $heroId = $hero->getId();
+                if (null === $heroId) {
+                    continue;
+                }
+                if (HeroStatus::Available !== $hero->getStatus()) {
+                    continue;
+                }
+                if ($hero->isTrainer()) {
+                    continue; // Never dismiss active trainers
+                }
+                if (!$this->isPurelyNegativeTrait($hero->getTrait())) {
+                    continue; // Only negative-trait heroes
+                }
 
-                    // Keep if high-level — could still become a trainer at some point
-                    if ($hero->getLevel() >= 4) {
-                        continue;
-                    }
+                // Keep if high-level — could still become a trainer at some point
+                if ($hero->getLevel() >= 4) {
+                    continue;
+                }
 
-                    // Keep if in active formation (we need the body count)
-                    $activeFormationsTrait = $this->em->getRepository(Formation::class)->findBy(['team' => $team]);
-                    $activeHeroIdsTrait = [];
-                    foreach ($activeFormationsTrait as $form) {
-                        foreach ($form->getSlots() as $slot) {
-                            $heroInSlot = $slot->getHero();
-                            if (null !== $heroInSlot && null !== $heroInSlot->getId()) {
-                                $activeHeroIdsTrait[$heroInSlot->getId()] = true;
-                            }
+                // Keep if in active formation (we need the body count)
+                $activeFormationsTrait = $this->em->getRepository(Formation::class)->findBy(['team' => $team]);
+                $activeHeroIdsTrait = [];
+                foreach ($activeFormationsTrait as $form) {
+                    foreach ($form->getSlots() as $slot) {
+                        $heroInSlot = $slot->getHero();
+                        if (null !== $heroInSlot && null !== $heroInSlot->getId()) {
+                            $activeHeroIdsTrait[$heroInSlot->getId()] = true;
                         }
                     }
-                    if (isset($activeHeroIdsTrait[$heroId])) {
-                        continue;
-                    }
+                }
+                if (isset($activeHeroIdsTrait[$heroId])) {
+                    continue;
+                }
 
-                    try {
-                        $this->dismissalService->dismiss($team, $hero);
-                        $aliveHeroes = array_filter($aliveHeroes, static fn (Hero $h) => $h->getId() !== $heroId);
-                        $heroCount = count($aliveHeroes);
-                        break; // Dismiss at most one negative-trait hero per tick
-                    } catch (\Throwable) {
-                        // Dismissal failed, continue
-                    }
+                try {
+                    $this->dismissalService->dismiss($team, $hero);
+                    $aliveHeroes = array_filter($aliveHeroes, static fn (Hero $h) => $h->getId() !== $heroId);
+                    $heroCount = count($aliveHeroes);
+                    --$combatantCount;
+                    break; // Dismiss at most one negative-trait hero per tick
+                } catch (\Throwable) {
+                    // Dismissal failed, continue
                 }
             }
 
             // 0b. Recycle Roster: If roster is full and we have at least 1 hero listed for sale,
             // dismiss the worst available combatant to make room for a new summon.
-            if ($heroCount >= $rosterLimit && $sellingCount >= 1) {
+            if ($combatantCount >= $rosterLimit && $sellingCount >= 1) {
                 $summonStatus = $this->summoningService->getStatus($team);
                 if ($team->getGold() >= ($summonStatus['gold_cost'] + 150)) {
                     // Find active formation hero IDs to avoid dismissing active combatants
@@ -636,6 +629,7 @@ class NpcSimulationService
                             // Refresh hero list and count
                             $aliveHeroes = array_filter($aliveHeroes, static fn (Hero $h) => $h->getId() !== $worstHero->getId());
                             $heroCount = count($aliveHeroes);
+                            --$combatantCount;
                         } catch (\Throwable) {
                             // Dismissal failed, ignore
                         }
@@ -647,78 +641,59 @@ class NpcSimulationService
             // NPC teams keep summoning to train and sell up to roster limit whenever they have space
             $summonThreshold = $rosterLimit - 1;
 
-            if ($heroCount <= $summonThreshold) {
+            if ($combatantCount <= $summonThreshold) {
                 $summonStatus = $this->summoningService->getStatus($team);
                 if ($summonStatus['available'] && $team->getGold() >= ($summonStatus['gold_cost'] + 150)) {
                     try {
                         $this->summoningService->summon($team);
-                        ++$heroCount;
                     } catch (\Throwable) {
                         // Summon failed, ignore
                     }
                 }
             }
+        }
 
-            // 2. HQ Upgrades
+        $this->em->flush();
+    }
+
+    /**
+     * Run marketplace simulation: buying and selling items/heroes twice weekly.
+     */
+    public function simulateMarketplaceActions(Kingdom $kingdom, \DateTimeImmutable $now, ?Team $team = null): void
+    {
+        if (null !== $team) {
+            if (!$team->isNpc()) {
+                return;
+            }
+            $teams = [$team];
+        } else {
+            $teams = $this->em->getRepository(Team::class)->findBy([
+                'kingdom' => $kingdom,
+                'isNpc' => true,
+            ]);
+        }
+
+        foreach ($teams as $team) {
+            $role = $this->getEconomicRole($team);
+
+            // Fetch alive heroes
+            $aliveHeroes = $this->em->getRepository(Hero::class)->createQueryBuilder('h')
+                ->where('h.team = :team')
+                ->andWhere('h.status NOT IN (:deadStatuses)')
+                ->setParameter('team', $team)
+                ->setParameter('deadStatuses', [HeroStatus::Dead, HeroStatus::Retired])
+                ->getQuery()
+                ->getResult();
+
+            $heroCount = count($aliveHeroes);
+
+            // HQ reference for safety reserve
             $hq = $this->hqService->getForTeam($team);
             $weeklyMaintenance = $this->hqService->calculateWeeklyMaintenanceFee($hq);
             $safetyReserve = 2 * $weeklyMaintenance;
 
-            if (null === $hq->getUpgradingFacility()) {
-                $priorities = $this->getFacilityPrioritiesForRole($role);
-                $upgradeCandidates = [];
-                foreach ($hq->getFacilities() as $facility) {
-                    $facilityType = $facility->getType();
-                    $priorityIndex = array_search($facilityType, $priorities, true);
-                    if (false === $priorityIndex) {
-                        $priorityIndex = 3;
-                    }
-
-                    $upgradeCandidates[] = [
-                        'facility' => $facility,
-                        'type' => $facilityType,
-                        'level' => $facility->getLevel(),
-                        'priorityIndex' => $priorityIndex,
-                    ];
-                }
-
-                // Sort candidates: first by level ascending (balance levels), then by priorityIndex ascending
-                usort($upgradeCandidates, static function (array $a, array $b): int {
-                    if ($a['level'] !== $b['level']) {
-                        return $a['level'] <=> $b['level'];
-                    }
-
-                    return $a['priorityIndex'] <=> $b['priorityIndex'];
-                });
-
-                foreach ($upgradeCandidates as $candidate) {
-                    $facility = $candidate['facility'];
-                    $facilityType = $candidate['type'];
-                    $cost = $this->hqService->calculateUpgradeCost($facilityType, $facility->getLevel(), $hq->getComputedTotalLevel());
-                    if ($team->getGold() >= ($safetyReserve + $cost)) {
-                        // Compute level difference constraint among ALL facilities:
-                        // Level difference between highest and lowest facilities after this upgrade must be <= 3
-                        $tempLevels = [];
-                        foreach ($upgradeCandidates as $uc) {
-                            $tempLevels[] = ($uc['type'] === $facilityType) ? $uc['level'] + 1 : $uc['level'];
-                        }
-                        $maxLevel = max($tempLevels);
-                        $minLevel = min($tempLevels);
-
-                        if (($maxLevel - $minLevel) <= 3) {
-                            try {
-                                $this->hqService->upgradeFacility($team, $facilityType, $now);
-                                break; // Upgrade at most one facility per week
-                            } catch (\Throwable) {
-                                // Try next candidate
-                            }
-                        }
-                    }
-                }
-            }
-
             // 3. Marketplace - Selling (Item and Hero/Trainer)
-            // Limit to at most 1 item and 1 hero/trainer listing per week to avoid spam
+            // Limit to at most 1 item and 1 hero/trainer listing per tick to avoid spam
             $unequippedItems = $this->em->getRepository(Item::class)->findBy([
                 'ownerTeam' => $team,
                 'status' => ItemStatus::Available,
@@ -764,7 +739,8 @@ class NpcSimulationService
                     }
                 }
 
-                $sellingCandidate = null;
+                $combatantCandidates = [];
+                $trainerCandidates = [];
                 foreach ($aliveHeroes as $hero) {
                     $heroId = $hero->getId();
                     if (null === $heroId) {
@@ -776,22 +752,53 @@ class NpcSimulationService
                     if (isset($activeHeroIds[$heroId])) {
                         continue;
                     }
+                    if ($hero->getLevel() < 1) {
+                        continue;
+                    }
 
-                    if (self::ROLE_MERCENARY_ACADEMY === $role) {
-                        if (!$hero->isTrainer() && $hero->getLevel() >= 1) {
-                            $sellingCandidate = $hero;
-                            break;
-                        }
-                    } elseif (self::ROLE_VETERAN_GUILD === $role) {
-                        if ($hero->isTrainer()) {
-                            $sellingCandidate = $hero;
-                            break;
-                        }
+                    if ($hero->isTrainer()) {
+                        $trainerCandidates[] = $hero;
                     } else {
-                        if ($hero->getLevel() >= 1) {
-                            $sellingCandidate = $hero;
-                            break;
-                        }
+                        $combatantCandidates[] = $hero;
+                    }
+                }
+
+                $theme = $this->summoningService->getArenaRaceTheme($team);
+
+                // Sort combatants: prioritize those with negative traits and lower compatibility
+                usort($combatantCandidates, function (Hero $a, Hero $b) use ($theme): int {
+                    $hasNegA = 'negative' === $a->getTrait()?->getCategory();
+                    $hasNegB = 'negative' === $b->getTrait()?->getCategory();
+
+                    $relA = $theme ? $this->raceConfig->getRelationship($a->getRace(), $theme) : 100;
+                    $relB = $theme ? $this->raceConfig->getRelationship($b->getRace(), $theme) : 100;
+
+                    $priorityA = ($hasNegA ? 100 : 0) + (100 - $relA);
+                    $priorityB = ($hasNegB ? 100 : 0) + (100 - $relB);
+
+                    return $priorityB <=> $priorityA;
+                });
+
+                // Sort trainers: prioritize those with negative traits
+                usort($trainerCandidates, static function (Hero $a, Hero $b): int {
+                    $hasNegA = 'negative' === $a->getTrait()?->getCategory();
+                    $hasNegB = 'negative' === $b->getTrait()?->getCategory();
+
+                    return ($hasNegB ? 1 : 0) <=> ($hasNegA ? 1 : 0);
+                });
+
+                $sellingCandidate = null;
+                if (self::ROLE_VETERAN_GUILD === $role) {
+                    if (count($trainerCandidates) > 0) {
+                        $sellingCandidate = $trainerCandidates[0];
+                    } elseif (count($combatantCandidates) > 0) {
+                        $sellingCandidate = $combatantCandidates[0];
+                    }
+                } else {
+                    if (count($combatantCandidates) > 0) {
+                        $sellingCandidate = $combatantCandidates[0];
+                    } elseif (count($trainerCandidates) > 0) {
+                        $sellingCandidate = $trainerCandidates[0];
                     }
                 }
 
@@ -819,11 +826,14 @@ class NpcSimulationService
             }
 
             // 4. Marketplace - Buying
-            // Scan and buy player listings in the same Kingdom if budget allows
+            // Scan and buy player listings in the same Kingdom if budget allows, based on priority score
             $listings = $this->em->getRepository(MarketplaceListing::class)->findBy([
                 'kingdom' => $kingdom,
                 'status' => ListingStatus::Active,
             ], ['id' => 'ASC'], 20);
+
+            $bestListing = null;
+            $bestScore = -1;
 
             foreach ($listings as $listing) {
                 if ($listing->getSellerTeam()->getId() === $team->getId()) {
@@ -835,52 +845,162 @@ class NpcSimulationService
                     continue;
                 }
 
-                $shouldBuy = false;
+                $score = 0; // 0 means not interested
 
-                if (self::ROLE_ROYAL_COLLECTOR === $role) {
-                    // Rich collectors buy high-end items and heroes
-                    if (ListingType::Item === $listing->getListingType()) {
-                        $item = $listing->getItem();
-                        if (null !== $item && in_array($item->getRarity(), [ItemRarity::Epic, ItemRarity::Legendary, ItemRarity::Mythic], true)) {
-                            $shouldBuy = true;
-                        }
-                    } elseif (in_array($listing->getListingType(), [ListingType::Hero, ListingType::Trainer], true)) {
-                        $hero = $listing->getHero();
-                        if (null !== $hero && $hero->getLevel() >= 1) {
-                            $shouldBuy = true;
-                        }
-                    }
-                } elseif (self::ROLE_SCAVENGER_CLAN === $role) {
-                    // Scavengers buy cheap items to dismantle
-                    if (ListingType::Item === $listing->getListingType() && $price < 150) {
-                        $shouldBuy = true;
-                    }
-                } elseif (self::ROLE_MERCENARY_ACADEMY === $role) {
-                    // Mercenary Academies buy physical/combat heroes
-                    if (ListingType::Hero === $listing->getListingType()) {
-                        $hero = $listing->getHero();
-                        if (null !== $hero && $hero->getLevel() >= 1 && in_array($hero->getRace(), [Race::Orc, Race::Dwarf, Race::Human], true)) {
-                            $shouldBuy = true;
+                if (ListingType::Item === $listing->getListingType()) {
+                    $item = $listing->getItem();
+                    if (null !== $item) {
+                        if (self::ROLE_ROYAL_COLLECTOR === $role) {
+                            if (in_array($item->getRarity(), [ItemRarity::Epic, ItemRarity::Legendary, ItemRarity::Mythic], true)) {
+                                $score = 100;
+                            } else {
+                                $score = 10;
+                            }
+                        } elseif (self::ROLE_SCAVENGER_CLAN === $role) {
+                            if ($price < 150) {
+                                $score = 100;
+                            } else {
+                                $score = 20;
+                            }
+                        } else {
+                            if (in_array($item->getRarity(), [ItemRarity::Epic, ItemRarity::Rare], true) && $price < 300) {
+                                $score = 30;
+                            }
                         }
                     }
-                } elseif (self::ROLE_VETERAN_GUILD === $role) {
-                    // Veteran Guilds buy trainers
-                    if (ListingType::Trainer === $listing->getListingType()) {
-                        $hero = $listing->getHero();
-                        if (null !== $hero && $hero->getLevel() >= 1) {
-                            $shouldBuy = true;
+                } elseif (ListingType::Hero === $listing->getListingType()) {
+                    $hero = $listing->getHero();
+                    if (null !== $hero && $hero->getLevel() >= 1) {
+                        $theme = $this->summoningService->getArenaRaceTheme($team);
+                        if (Race::Genie === $theme) {
+                            $compatibleRaces = [Race::Genie];
+                        } else {
+                            $compatibleRaces = $this->summoningService->getCompatibleRacesForTeam($team);
+                        }
+
+                        if (!in_array($hero->getRace(), $compatibleRaces, true)) {
+                            $score = 0;
+                        } else {
+                            if (self::ROLE_MERCENARY_ACADEMY === $role) {
+                                if (in_array($hero->getRace(), [Race::Orc, Race::Dwarf, Race::Human], true)) {
+                                    $score = 100;
+                                } else {
+                                    $score = 60;
+                                }
+                            } elseif (self::ROLE_ROYAL_COLLECTOR === $role) {
+                                $score = 80;
+                            } else {
+                                $score = 20;
+                            }
+                        }
+                    }
+                } elseif (ListingType::Trainer === $listing->getListingType()) {
+                    $hero = $listing->getHero();
+                    if (null !== $hero && $hero->getLevel() >= 1) {
+                        if (self::ROLE_VETERAN_GUILD === $role) {
+                            $score = 100;
+                        } elseif (self::ROLE_ROYAL_COLLECTOR === $role) {
+                            $score = 80;
+                        } else {
+                            $score = 20;
                         }
                     }
                 }
 
-                if ($shouldBuy) {
-                    $listingId = $listing->getId();
-                    if (null !== $listingId) {
-                        try {
-                            $this->marketplaceService->buyListing($team, $listingId, $now);
-                            break; // Buy at most one listing per week to maintain budget
-                        } catch (\Throwable) {
-                            // Ignore buy error
+                if ($score > 0 && $score > $bestScore) {
+                    $bestScore = $score;
+                    $bestListing = $listing;
+                }
+            }
+
+            if (null !== $bestListing) {
+                $listingId = $bestListing->getId();
+                if (null !== $listingId) {
+                    try {
+                        $this->marketplaceService->buyListing($team, $listingId, $now);
+                    } catch (\Throwable) {
+                        // Ignore buy error
+                    }
+                }
+            }
+        }
+
+        $this->em->flush();
+    }
+
+    /**
+     * Run weekly management and economy simulation: HQ upgrades.
+     */
+    public function simulateWeeklyManagementAndEconomy(Kingdom $kingdom, \DateTimeImmutable $now, ?Team $team = null): void
+    {
+        if (null !== $team) {
+            if (!$team->isNpc()) {
+                return;
+            }
+            $teams = [$team];
+        } else {
+            $teams = $this->em->getRepository(Team::class)->findBy([
+                'kingdom' => $kingdom,
+                'isNpc' => true,
+            ]);
+        }
+
+        foreach ($teams as $team) {
+            $role = $this->getEconomicRole($team);
+
+            // 2. HQ Upgrades
+            $hq = $this->hqService->getForTeam($team);
+            $weeklyMaintenance = $this->hqService->calculateWeeklyMaintenanceFee($hq);
+            $safetyReserve = 2 * $weeklyMaintenance;
+
+            if (null === $hq->getUpgradingFacility()) {
+                $priorities = $this->getFacilityPrioritiesForRole($role);
+                $upgradeCandidates = [];
+                foreach ($hq->getFacilities() as $facility) {
+                    $facilityType = $facility->getType();
+                    $priorityIndex = array_search($facilityType, $priorities, true);
+                    if (false === $priorityIndex) {
+                        $priorityIndex = 3;
+                    }
+
+                    $upgradeCandidates[] = [
+                        'facility' => $facility,
+                        'type' => $facilityType,
+                        'level' => $facility->getLevel(),
+                        'priorityIndex' => $priorityIndex,
+                    ];
+                }
+
+                // Sort candidates: first by priorityIndex ascending (higher priority first), then by level ascending (balance equal priorities)
+                usort($upgradeCandidates, static function (array $a, array $b): int {
+                    if ($a['priorityIndex'] !== $b['priorityIndex']) {
+                        return $a['priorityIndex'] <=> $b['priorityIndex'];
+                    }
+
+                    return $a['level'] <=> $b['level'];
+                });
+
+                foreach ($upgradeCandidates as $candidate) {
+                    $facility = $candidate['facility'];
+                    $facilityType = $candidate['type'];
+                    $cost = $this->hqService->calculateUpgradeCost($facilityType, $facility->getLevel(), $hq->getComputedTotalLevel());
+                    if ($team->getGold() >= ($safetyReserve + $cost)) {
+                        // Compute level difference constraint among ALL facilities:
+                        // Level difference between highest and lowest facilities after this upgrade must be <= 3
+                        $tempLevels = [];
+                        foreach ($upgradeCandidates as $uc) {
+                            $tempLevels[] = ($uc['type'] === $facilityType) ? $uc['level'] + 1 : $uc['level'];
+                        }
+                        $maxLevel = max($tempLevels);
+                        $minLevel = min($tempLevels);
+
+                        if (($maxLevel - $minLevel) <= 3) {
+                            try {
+                                $this->hqService->upgradeFacility($team, $facilityType, $now);
+                                break; // Upgrade at most one facility per week
+                            } catch (\Throwable) {
+                                // Try next candidate
+                            }
                         }
                     }
                 }

--- a/src/Service/TeamChronicle/TeamChronicleService.php
+++ b/src/Service/TeamChronicle/TeamChronicleService.php
@@ -7,6 +7,7 @@ namespace App\Service\TeamChronicle;
 use App\Entity\Auth\User;
 use App\Entity\Combat\Battle;
 use App\Entity\Hero\Hero;
+use App\Entity\Item\Item;
 use App\Entity\Kingdom\Kingdom;
 use App\Entity\Team\Team;
 use App\Entity\Team\TeamChronicle;
@@ -14,6 +15,7 @@ use App\Enum\ChronicleEventType;
 use App\Enum\ChronicleReleaseReason;
 use App\Enum\Race;
 use App\Service\Calendar\TickClock;
+use App\Service\Translation\UserMessageTranslator;
 use Doctrine\ORM\EntityManagerInterface;
 
 class TeamChronicleService
@@ -21,6 +23,7 @@ class TeamChronicleService
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly TickClock $tickClock,
+        private readonly UserMessageTranslator $translator,
     ) {
     }
 
@@ -359,6 +362,46 @@ class TeamChronicleService
             [
                 'race' => $race,
             ]
+        );
+    }
+
+    public function recordItemPurchased(Team $buyer, Item $item, ?Team $seller, int $price): TeamChronicle
+    {
+        $sellerName = $seller?->getName() ?? $this->translator->trans('marketplace.merchant');
+
+        return $this->create(
+            $buyer,
+            ChronicleEventType::ItemPurchased,
+            'activity.item_purchased',
+            [
+                'item' => $item->getName(),
+                'seller' => $sellerName,
+                'price' => (string) $price,
+            ],
+            [
+                'item_id' => $item->getId(),
+                'seller_team_id' => $seller?->getId(),
+                'price' => $price,
+            ],
+        );
+    }
+
+    public function recordItemSold(Team $seller, Item $item, Team $buyer, int $price): TeamChronicle
+    {
+        return $this->create(
+            $seller,
+            ChronicleEventType::ItemSold,
+            'activity.item_sold',
+            [
+                'item' => $item->getName(),
+                'buyer' => $buyer->getName(),
+                'price' => (string) $price,
+            ],
+            [
+                'item_id' => $item->getId(),
+                'buyer_team_id' => $buyer->getId(),
+                'price' => $price,
+            ],
         );
     }
 

--- a/src/Service/Training/TrainingService.php
+++ b/src/Service/Training/TrainingService.php
@@ -6,6 +6,7 @@ namespace App\Service\Training;
 
 use App\Entity\Hero\Hero;
 use App\Entity\Hero\HeroTrainingHistory;
+use App\Entity\Item\Item;
 use App\Entity\Team\Team;
 use App\Enum\HeroRole;
 use App\Enum\HeroStatus;
@@ -122,6 +123,13 @@ class TrainingService
         $hero->setRole(HeroRole::Trainer);
         $hero->setTrainingType(null);
         $hero->setTargetAttribute(null);
+
+        // Unequip all items from the hero being promoted to trainer
+        $equippedItems = $this->em->getRepository(Item::class)->findBy(['equippedHero' => $hero]);
+        foreach ($equippedItems as $item) {
+            $item->setEquippedHero(null);
+            $item->setEquippedSlot(null);
+        }
 
         // Remove hero from active formations
         /** @var list<\App\Entity\Formation\FormationSlot> $slots */

--- a/src/Twig/GameExtension.php
+++ b/src/Twig/GameExtension.php
@@ -163,7 +163,7 @@ class GameExtension extends AbstractExtension
 
     public function getTeamHeroCount(Team $team): int
     {
-        return $this->heroRepository->count(['team' => $team]);
+        return $this->heroRepository->countActiveCombatantsByTeam($team);
     }
 
     /**

--- a/tests/Service/Calendar/ProcessKingdomTicksHandlerTest.php
+++ b/tests/Service/Calendar/ProcessKingdomTicksHandlerTest.php
@@ -65,6 +65,16 @@ class ProcessKingdomTicksHandlerTest extends TestCase
     {
         $this->tickLogRepositoryMock = $this->createMock(KingdomTickLogRepository::class);
         $this->heroRepositoryMock = $this->createMock(HeroRepository::class);
+        $heroQbMock = $this->createMock(\Doctrine\ORM\QueryBuilder::class);
+        $heroQueryMock = $this->createMock(\Doctrine\ORM\Query::class);
+        $heroQbMock->method('join')->willReturnSelf();
+        $heroQbMock->method('where')->willReturnSelf();
+        $heroQbMock->method('andWhere')->willReturnSelf();
+        $heroQbMock->method('setParameter')->willReturnSelf();
+        $heroQbMock->method('getQuery')->willReturn($heroQueryMock);
+        $heroQueryMock->method('getResult')->willReturn([]);
+        $this->heroRepositoryMock->method('createQueryBuilder')->willReturn($heroQbMock);
+
         $this->trainingServiceMock = $this->createMock(TrainingService::class);
         $this->arenaRevenueServiceMock = $this->createMock(ArenaRevenueService::class);
         $this->fanClubServiceMock = $this->createMock(\App\Service\Team\FanClubService::class);

--- a/tests/Service/Item/ItemServiceTest.php
+++ b/tests/Service/Item/ItemServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Service\Item;
 
 use App\Entity\Hero\Hero;
 use App\Entity\Item\Item;
+use App\Entity\Marketplace\MarketplaceTransaction;
 use App\Entity\Team\Team;
 use App\Enum\ItemRarity;
 use App\Enum\ItemSlotType;
@@ -13,6 +14,8 @@ use App\Enum\ItemStatus;
 use App\Repository\Item\ItemRepository;
 use App\Exception\UserFacingException;
 use App\Service\Item\ItemService;
+use App\Service\Economy\EconomyService;
+use App\Service\TeamChronicle\TeamChronicleService;
 use App\Service\Translation\UserMessageTranslator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -28,6 +31,8 @@ class ItemServiceTest extends TestCase
     private EntityManagerInterface&MockObject $entityManagerMock;
     private TranslatorInterface&MockObject $symfonyTranslatorMock;
     private RequestStack&MockObject $requestStackMock;
+    private EconomyService&MockObject $economyServiceMock;
+    private TeamChronicleService&MockObject $teamChronicleServiceMock;
     private ItemService $itemService;
 
     protected function setUp(): void
@@ -36,13 +41,22 @@ class ItemServiceTest extends TestCase
         $this->entityManagerMock = $this->createMock(EntityManagerInterface::class);
         $this->symfonyTranslatorMock = $this->createMock(TranslatorInterface::class);
         $this->requestStackMock = $this->createMock(RequestStack::class);
+        $this->economyServiceMock = $this->createMock(EconomyService::class);
+        $this->economyServiceMock
+            ->method('deductGold')
+            ->willReturnCallback(static function (Team $team, int $amount): void {
+                $team->setGold($team->getGold() - $amount);
+            });
+        $this->teamChronicleServiceMock = $this->createMock(TeamChronicleService::class);
         
         $translator = new UserMessageTranslator($this->symfonyTranslatorMock, $this->requestStackMock);
         
         $this->itemService = new ItemService(
             $this->itemRepositoryMock,
             $this->entityManagerMock,
-            $translator
+            $translator,
+            $this->economyServiceMock,
+            $this->teamChronicleServiceMock
         );
     }
 
@@ -112,9 +126,9 @@ class ItemServiceTest extends TestCase
         $this->entityManagerMock
             ->method('persist')
             ->willReturnCallback(static function (object $entity): void {
-                self::assertInstanceOf(Item::class, $entity);
+                self::assertTrue($entity instanceof Item || $entity instanceof MarketplaceTransaction || $entity instanceof \App\Entity\Team\TeamChronicle);
             });
-        $this->entityManagerMock->expects($this->once())
+        $this->entityManagerMock->expects($this->exactly(2))
             ->method('flush');
 
         $item = $this->itemService->purchaseBasicItem($team, 'short_sword');

--- a/tests/Service/Marketplace/MarketplaceServiceTest.php
+++ b/tests/Service/Marketplace/MarketplaceServiceTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Tests\Service\Marketplace;
 
 use App\Entity\Hero\Hero;
+use App\Entity\Item\Item;
 use App\Entity\Marketplace\MarketplaceListing;
+use App\Entity\Kingdom\Kingdom;
 use App\Entity\Team\Team;
 use App\Enum\HeroStatus;
 use App\Enum\ListingMode;
@@ -15,13 +17,18 @@ use App\Service\Economy\EconomyService;
 use App\Service\Economy\FinancialCrisisService;
 use App\Exception\UserFacingException;
 use App\Service\Hero\HeroRatingCalculator;
+use App\Service\Headquarters\HeadquartersService;
 use App\Service\Marketplace\MarketplaceService;
 use App\Service\Notification\NotificationHelper;
 use App\Service\Team\TeamRosterService;
 use App\Service\Team\TeamChemistryService;
+use App\Service\Training\TrainingService;
+use App\Service\Translation\UserMessageTranslator;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 class MarketplaceServiceTest extends TestCase
@@ -46,6 +53,10 @@ class MarketplaceServiceTest extends TestCase
     private $heroRatingCalculatorMock;
     /** @var \PHPUnit\Framework\MockObject\MockObject&\App\Service\Config\RaceConfig */
     private $raceConfigMock;
+    /** @var \PHPUnit\Framework\MockObject\MockObject&HeadquartersService */
+    private $hqServiceMock;
+    /** @var \PHPUnit\Framework\MockObject\MockObject&TrainingService */
+    private $trainingServiceMock;
     private MarketplaceService $marketplaceService;
 
     protected function setUp(): void
@@ -60,6 +71,12 @@ class MarketplaceServiceTest extends TestCase
         $this->teamChemistryServiceMock = $this->createMock(TeamChemistryService::class);
         $this->heroRatingCalculatorMock = $this->createMock(HeroRatingCalculator::class);
         $this->raceConfigMock = $this->createMock(\App\Service\Config\RaceConfig::class);
+        $this->hqServiceMock = $this->createMock(HeadquartersService::class);
+        $this->trainingServiceMock = $this->createMock(TrainingService::class);
+
+        $symfonyTranslatorMock = $this->createMock(TranslatorInterface::class);
+        $requestStackMock = $this->createMock(RequestStack::class);
+        $translator = new UserMessageTranslator($symfonyTranslatorMock, $requestStackMock);
 
         $this->marketplaceService = new MarketplaceService(
             $this->entityManagerMock,
@@ -72,6 +89,9 @@ class MarketplaceServiceTest extends TestCase
             $this->teamChemistryServiceMock,
             $this->heroRatingCalculatorMock,
             $this->raceConfigMock,
+            $translator,
+            $this->hqServiceMock,
+            $this->trainingServiceMock,
         );
     }
 
@@ -144,5 +164,69 @@ class MarketplaceServiceTest extends TestCase
 
         $this->assertSame(HeroStatus::Available, $hero->getStatus());
         $this->assertSame(ListingStatus::Cancelled, $listing->getStatus());
+    }
+
+    public function testCreateListingUnequipsHeroItems(): void
+    {
+        $kingdom = new Kingdom();
+        $seller = new Team();
+        $seller->setKingdom($kingdom);
+        $hero = new Hero();
+        $hero->setTeam($seller);
+        $hero->setStatus(HeroStatus::Available);
+
+        $item = new Item();
+        $item->setOwnerTeam($seller);
+        $item->setEquippedHero($hero);
+        $item->setEquippedSlot(\App\Enum\ItemSlotType::MainHand);
+
+        $heroRepo = $this->createMock(\Doctrine\ORM\EntityRepository::class);
+        $heroRepo->method('find')->willReturn($hero);
+
+        $itemRepo = $this->createMock(\Doctrine\ORM\EntityRepository::class);
+        $itemRepo->expects($this->once())->method('findBy')
+            ->with(['equippedHero' => $hero])
+            ->willReturn([$item]);
+
+        $formationSlotRepo = $this->createMock(\Doctrine\ORM\EntityRepository::class);
+        $formationSlotRepo->method('findBy')->willReturn([]);
+
+        $this->entityManagerMock
+            ->method('getRepository')
+            ->willReturnCallback(function ($className) use ($heroRepo, $itemRepo, $formationSlotRepo) {
+                if ($className === Hero::class) {
+                    return $heroRepo;
+                }
+                if ($className === Item::class) {
+                    return $itemRepo;
+                }
+                if ($className === \App\Entity\Formation\FormationSlot::class) {
+                    return $formationSlotRepo;
+                }
+                throw new \InvalidArgumentException("Unexpected class name: $className");
+            });
+
+        $this->teamRosterServiceMock
+            ->expects($this->once())
+            ->method('assertCanRemoveCombatReadyHero')
+            ->with($seller, $hero);
+
+        $this->entityManagerMock->expects($this->once())->method('persist');
+        $this->entityManagerMock->expects($this->once())->method('flush');
+
+        $listing = $this->marketplaceService->createListing(
+            $seller,
+            ListingType::Hero->value,
+            1,
+            100,
+            null,
+            ListingMode::BuyNow->value,
+            7,
+            new \DateTimeImmutable('now')
+        );
+
+        $this->assertSame(HeroStatus::Selling, $hero->getStatus());
+        $this->assertNull($item->getEquippedHero());
+        $this->assertNull($item->getEquippedSlot());
     }
 }

--- a/tests/Service/Team/NpcSimulationServiceTest.php
+++ b/tests/Service/Team/NpcSimulationServiceTest.php
@@ -29,6 +29,7 @@ use App\Service\Summoning\SummoningService;
 use App\Service\Team\NpcSimulationService;
 use App\Service\Training\TrainingService;
 use App\Service\Hero\HeroDismissalService;
+use App\Service\Config\RaceConfig;
 use App\Service\Hero\HeroRatingCalculator;
 use App\Entity\Item\Item;
 use Doctrine\ORM\EntityManagerInterface;
@@ -56,6 +57,8 @@ class NpcSimulationServiceTest extends TestCase
     private $dismissalService;
     /** @var HeroRatingCalculator&MockObject */
     private $heroRatingCalculator;
+    /** @var RaceConfig&MockObject */
+    private $raceConfig;
     private NpcSimulationService $service;
 
     protected function setUp(): void
@@ -68,6 +71,7 @@ class NpcSimulationServiceTest extends TestCase
         $this->itemService = $this->createMock(ItemService::class);
         $this->dismissalService = $this->createMock(HeroDismissalService::class);
         $this->heroRatingCalculator = $this->createMock(HeroRatingCalculator::class);
+        $this->raceConfig = $this->createMock(RaceConfig::class);
 
         $this->service = new NpcSimulationService(
             $this->em,
@@ -78,6 +82,7 @@ class NpcSimulationServiceTest extends TestCase
             $this->itemService,
             $this->dismissalService,
             $this->heroRatingCalculator,
+            $this->raceConfig,
         );
     }
 
@@ -454,6 +459,14 @@ class NpcSimulationServiceTest extends TestCase
         $this->hqService->method('calculateWeeklyMaintenanceFee')->willReturn(50);
         $this->hqService->method('calculateUpgradeCost')->willReturn(500);
 
+        $this->summoningService->method('getStatus')->willReturn([
+            'available' => false,
+            'reason' => 'test',
+            'gold_cost' => 100,
+            'summons_used' => 0,
+            'summons_max' => 5,
+        ]);
+
         // Expect dismiss to be called on the Fragile hero (heroes[0])
         $calledDismissParams = null;
         $this->dismissalService->expects($this->once())
@@ -464,7 +477,7 @@ class NpcSimulationServiceTest extends TestCase
             });
 
         // Run
-        $this->service->simulateManagementAndEconomy($kingdom, new \DateTimeImmutable());
+        $this->service->simulateDailyManagementAndEconomy($kingdom, new \DateTimeImmutable());
 
         $this->assertNotNull($calledDismissParams);
         $this->assertSame($team, $calledDismissParams[0]);
@@ -545,7 +558,7 @@ class NpcSimulationServiceTest extends TestCase
             });
 
         // Run
-        $this->service->simulateManagementAndEconomy($kingdom, new \DateTimeImmutable());
+        $this->service->simulateMarketplaceActions($kingdom, new \DateTimeImmutable());
 
         $this->assertNotNull($calledListingParams);
         $this->assertSame($team, $calledListingParams[0]);
@@ -617,5 +630,168 @@ class NpcSimulationServiceTest extends TestCase
         $this->assertEquals(HeroRole::Trainer, $hero2->getRole());
         $this->assertEquals(HeroRole::Combatant, $hero1->getRole());
     }
+
+    public function testSimulateTrainingUnequipsItemsFromPromotedTrainer(): void
+    {
+        $kingdom = new Kingdom();
+        $team = new Team();
+        $this->setEntityId($team, 0); // ROLE_MERCENARY_ACADEMY
+        $team->setKingdom($kingdom);
+
+        $hero = new Hero();
+        $hero->setRole(HeroRole::Combatant);
+        $hero->setTeam($team);
+        $hero->setAgeRaw(300);
+        $hero->setLevel(10);
+        $hero->setStatus(HeroStatus::Available);
+        $this->setEntityId($hero, 123);
+
+        $hero2 = new Hero();
+        $hero2->setRole(HeroRole::Combatant);
+        $hero2->setTeam($team);
+        $hero2->setAgeRaw(100);
+        $hero2->setLevel(1);
+        $hero2->setStatus(HeroStatus::Available);
+        $this->setEntityId($hero2, 124);
+
+        $item = new Item();
+        $item->setOwnerTeam($team);
+        $item->setEquippedHero($hero);
+        $item->setEquippedSlot(ItemSlotType::MainHand);
+
+        $teamRepo = $this->createMock(EntityRepository::class);
+        $teamRepo->method('findBy')->willReturn([$team]);
+
+        $heroRepo = $this->createMock(HeroRepository::class);
+        $heroRepo->method('findBy')->willReturn([$hero, $hero2]);
+
+        $itemRepo = $this->createMock(EntityRepository::class);
+        $itemRepo->expects($this->once())->method('findBy')
+            ->with(['equippedHero' => $hero])
+            ->willReturn([$item]);
+
+        $formationRepo = $this->createMock(EntityRepository::class);
+        $formationRepo->method('findBy')->willReturn([]);
+
+        $this->em->method('getRepository')->willReturnCallback(function (string $class) use ($teamRepo, $heroRepo, $itemRepo, $formationRepo) {
+            if (Team::class === $class) return $teamRepo;
+            if (Hero::class === $class) return $heroRepo;
+            if (Item::class === $class) return $itemRepo;
+            if (Formation::class === $class) return $formationRepo;
+            return $this->createMock(EntityRepository::class);
+        });
+
+        $this->trainingService->method('getTrainerLimit')->willReturn(1);
+        $this->trainingService->method('getTrainerSlotsLimit')->willReturn(2);
+
+        $this->service->simulateTraining($kingdom, new \DateTimeImmutable());
+
+        $this->assertEquals(HeroRole::Trainer, $hero->getRole());
+        $this->assertNull($item->getEquippedHero());
+        $this->assertNull($item->getEquippedSlot());
+    }
+
+    public function testSimulateWeeklyManagementAndEconomyHqUpgrades(): void
+    {
+        $kingdom = new Kingdom();
+        $team = new Team();
+        $this->setEntityId($team, 0); // ROLE_MERCENARY_ACADEMY: Training (0), SummoningChamber (1), Barracks (2)
+        $team->setKingdom($kingdom);
+        $team->setIsNpc(true);
+        $team->setGold(10000);
+
+        $teamRepo = $this->createMock(EntityRepository::class);
+        $teamRepo->method('findBy')->willReturn([$team]);
+
+        $this->em->method('getRepository')->willReturnCallback(function (string $class) use ($teamRepo) {
+            if (Team::class === $class) return $teamRepo;
+            return $this->createMock(EntityRepository::class);
+        });
+
+        $hq = new Headquarters();
+        $hq->setTeam($team);
+
+        $training = new Facility();
+        $training->setType(FacilityType::Training);
+        $training->setLevel(3);
+        $hq->addFacility($training);
+
+        $summoning = new Facility();
+        $summoning->setType(FacilityType::SummoningChamber);
+        $summoning->setLevel(1);
+        $hq->addFacility($summoning);
+
+        $barracks = new Facility();
+        $barracks->setType(FacilityType::Barracks);
+        $barracks->setLevel(1);
+        $hq->addFacility($barracks);
+
+        $treasury = new Facility();
+        $treasury->setType(FacilityType::Treasury);
+        $treasury->setLevel(1);
+        $hq->addFacility($treasury);
+
+        $this->hqService->method('getForTeam')->willReturn($hq);
+        $this->hqService->method('calculateWeeklyMaintenanceFee')->willReturn(50);
+        $this->hqService->method('calculateUpgradeCost')->willReturn(100);
+
+        $this->hqService->expects($this->once())
+            ->method('upgradeFacility')
+            ->with($team, FacilityType::Training);
+
+        $this->service->simulateWeeklyManagementAndEconomy($kingdom, new \DateTimeImmutable(), $team);
+    }
+
+    public function testSimulateWeeklyManagementAndEconomyHqUpgradesExceedingLimitFallsBack(): void
+    {
+        $kingdom = new Kingdom();
+        $team = new Team();
+        $this->setEntityId($team, 0); // ROLE_MERCENARY_ACADEMY: Training (0), SummoningChamber (1), Barracks (2)
+        $team->setKingdom($kingdom);
+        $team->setIsNpc(true);
+        $team->setGold(10000);
+
+        $teamRepo = $this->createMock(EntityRepository::class);
+        $teamRepo->method('findBy')->willReturn([$team]);
+
+        $this->em->method('getRepository')->willReturnCallback(function (string $class) use ($teamRepo) {
+            if (Team::class === $class) return $teamRepo;
+            return $this->createMock(EntityRepository::class);
+        });
+
+        $hq = new Headquarters();
+        $hq->setTeam($team);
+
+        $training = new Facility();
+        $training->setType(FacilityType::Training);
+        $training->setLevel(4);
+        $hq->addFacility($training);
+
+        $summoning = new Facility();
+        $summoning->setType(FacilityType::SummoningChamber);
+        $summoning->setLevel(1);
+        $hq->addFacility($summoning);
+
+        $barracks = new Facility();
+        $barracks->setType(FacilityType::Barracks);
+        $barracks->setLevel(1);
+        $hq->addFacility($barracks);
+
+        $treasury = new Facility();
+        $treasury->setType(FacilityType::Treasury);
+        $treasury->setLevel(1);
+        $hq->addFacility($treasury);
+
+        $this->hqService->method('getForTeam')->willReturn($hq);
+        $this->hqService->method('calculateWeeklyMaintenanceFee')->willReturn(50);
+        $this->hqService->method('calculateUpgradeCost')->willReturn(100);
+
+        $this->hqService->expects($this->once())
+            ->method('upgradeFacility')
+            ->with($team, FacilityType::SummoningChamber);
+
+        $this->service->simulateWeeklyManagementAndEconomy($kingdom, new \DateTimeImmutable(), $team);
+    }
 }
+
 

--- a/tests/Service/TeamChronicle/TeamChronicleServiceTest.php
+++ b/tests/Service/TeamChronicle/TeamChronicleServiceTest.php
@@ -12,9 +12,12 @@ use App\Enum\ChronicleReleaseReason;
 use App\Enum\ChronicleEventType;
 use App\Enum\Race;
 use App\Service\TeamChronicle\TeamChronicleService;
+use App\Service\Translation\UserMessageTranslator;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 class TeamChronicleServiceTest extends TestCase
@@ -36,7 +39,7 @@ class TeamChronicleServiceTest extends TestCase
         $user = new User();
         $user->setDisplayName('Alice');
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $service->recordPlayerJoined($team, $user);
     }
 
@@ -57,7 +60,7 @@ class TeamChronicleServiceTest extends TestCase
         $user = new User();
         $user->setDisplayName('Bob');
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $service->recordPlayerReleased($team, $user, ChronicleReleaseReason::Bankruptcy);
     }
 
@@ -70,7 +73,7 @@ class TeamChronicleServiceTest extends TestCase
         $kingdom->setName('Test Kingdom');
         $team = new Team();
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $log = $service->recordTeamEstablished($team, $kingdom, 1);
 
         $this->assertSame(ChronicleEventType::TeamEstablished, $log->getType());
@@ -84,7 +87,7 @@ class TeamChronicleServiceTest extends TestCase
         $em->expects($this->once())->method('persist');
 
         $team = new Team();
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $log = $service->recordSeasonEnded($team, 2, 'T1', 4, '', 1000);
 
         $this->assertSame('maintained', $log->getSubjectParams()['status']);
@@ -100,7 +103,7 @@ class TeamChronicleServiceTest extends TestCase
         $hero = new \App\Entity\Hero\Hero();
         $hero->setName('Thorin');
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $log = $service->recordSummonCompleted($team, $hero, Race::Dwarf, 750);
 
         $this->assertSame(ChronicleEventType::SummonCompleted, $log->getType());
@@ -125,7 +128,7 @@ class TeamChronicleServiceTest extends TestCase
         $user = new User();
         $user->setDisplayName('Alice');
 
-        $service = new TeamChronicleService($em, $clock);
+        $service = $this->createService($em, $clock);
         $service->recordPlayerJoined($team, $user);
     }
 
@@ -150,7 +153,7 @@ class TeamChronicleServiceTest extends TestCase
         $idProp = $reflection->getProperty('id');
         $idProp->setValue($hero, 123);
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $service->recordHeroDismissed($team, $hero, 200);
     }
 
@@ -175,7 +178,7 @@ class TeamChronicleServiceTest extends TestCase
         $idProp = $reflection->getProperty('id');
         $idProp->setValue($trainer, 456);
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $service->recordTrainerDismissed($team, $trainer, 150);
     }
 
@@ -218,7 +221,7 @@ class TeamChronicleServiceTest extends TestCase
         $heroId = $heroReflection->getProperty('id');
         $heroId->setValue($hero, 123);
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $service->recordHeroPurchased($buyer, $hero, $seller, 500);
         $service->recordHeroSold($seller, $hero, $buyer, 500);
     }
@@ -239,7 +242,60 @@ class TeamChronicleServiceTest extends TestCase
 
         $team = new Team();
 
-        $service = new TeamChronicleService($em, new \App\Service\Calendar\TickClock());
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
         $service->recordTeamRenamed($team, 'Old Name', 'New Name');
+    }
+
+    public function testRecordItemPurchasedAndSoldPersistExpectedEntries(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->exactly(2))
+            ->method('persist')
+            ->with($this->callback(function (TeamChronicle $log): bool {
+                if (ChronicleEventType::ItemPurchased === $log->getType()) {
+                    $this->assertSame('activity.item_purchased', $log->getSubjectKey());
+                    $this->assertSame(['item' => 'Iron Sword', 'seller' => 'Sellers', 'price' => '300'], $log->getSubjectParams());
+                    $this->assertSame(['item_id' => 789, 'seller_team_id' => 2, 'price' => 300], $log->getData());
+                } else {
+                    $this->assertSame(ChronicleEventType::ItemSold, $log->getType());
+                    $this->assertSame('activity.item_sold', $log->getSubjectKey());
+                    $this->assertSame(['item' => 'Iron Sword', 'buyer' => 'Buyers', 'price' => '300'], $log->getSubjectParams());
+                    $this->assertSame(['item_id' => 789, 'buyer_team_id' => 1, 'price' => 300], $log->getData());
+                }
+
+                return true;
+            }));
+
+        $buyer = new Team();
+        $buyerReflection = new \ReflectionClass($buyer);
+        $buyerId = $buyerReflection->getProperty('id');
+        $buyerId->setValue($buyer, 1);
+        $buyer->setName('Buyers');
+
+        $seller = new Team();
+        $sellerReflection = new \ReflectionClass($seller);
+        $sellerId = $sellerReflection->getProperty('id');
+        $sellerId->setValue($seller, 2);
+        $seller->setName('Sellers');
+
+        $item = new \App\Entity\Item\Item();
+        $item->setName('Iron Sword');
+        $itemReflection = new \ReflectionClass($item);
+        $itemId = $itemReflection->getProperty('id');
+        $itemId->setValue($item, 789);
+
+        $service = $this->createService($em, new \App\Service\Calendar\TickClock());
+        $service->recordItemPurchased($buyer, $item, $seller, 300);
+        $service->recordItemSold($seller, $item, $buyer, 300);
+    }
+
+    private function createService(EntityManagerInterface $em, \App\Service\Calendar\TickClock $clock): TeamChronicleService
+    {
+        $symfonyTranslatorMock = $this->createMock(TranslatorInterface::class);
+        $symfonyTranslatorMock->method('trans')->willReturn('Merchant');
+        $requestStackMock = $this->createMock(RequestStack::class);
+        $translator = new UserMessageTranslator($symfonyTranslatorMock, $requestStackMock);
+
+        return new TeamChronicleService($em, $clock, $translator);
     }
 }

--- a/tests/Service/Training/TrainingServiceTest.php
+++ b/tests/Service/Training/TrainingServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\Team\Team;
 use App\Entity\Kingdom\Kingdom;
 use App\Entity\Headquarters\Headquarters;
 use App\Entity\Headquarters\Facility;
+use App\Entity\Item\Item;
 use App\Entity\Hero\HeroTrainingHistory;
 use App\Enum\FacilityType;
 use App\Enum\HeroRole;
@@ -310,5 +311,66 @@ class TrainingServiceTest extends TestCase
         $this->heroRepositoryMock
             ->method('createQueryBuilder')
             ->willReturn($qbMock);
+    }
+
+    public function testPromoteToTrainerUnequipsItems(): void
+    {
+        $team = $this->createMock(Team::class);
+        $team->method('getId')->willReturn(1);
+        $kingdom = $this->createMock(Kingdom::class);
+        $kingdom->method('getTimezone')->willReturn('UTC');
+        $team->method('getKingdom')->willReturn($kingdom);
+
+        $hero = new Hero();
+        $hero->setRole(HeroRole::Combatant);
+        $hero->setTeam($team);
+        $hero->setStatus(HeroStatus::Available);
+
+        $item = new Item();
+        $item->setOwnerTeam($team);
+        $item->setEquippedHero($hero);
+        $item->setEquippedSlot(\App\Enum\ItemSlotType::MainHand);
+
+        $this->heroRepositoryMock
+            ->expects($this->once())
+            ->method('countTrainersByTeam')
+            ->with($team)
+            ->willReturn(0);
+
+        $hq = new Headquarters();
+        $this->hqRepositoryMock
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['team' => $team])
+            ->willReturn($hq);
+
+        $itemRepo = $this->createMock(\Doctrine\ORM\EntityRepository::class);
+        $itemRepo->expects($this->once())->method('findBy')
+            ->with(['equippedHero' => $hero])
+            ->willReturn([$item]);
+
+        $formationSlotRepo = $this->createMock(\Doctrine\ORM\EntityRepository::class);
+        $formationSlotRepo->method('findBy')->willReturn([]);
+
+        $this->entityManagerMock
+            ->method('getRepository')
+            ->willReturnCallback(function ($className) use ($itemRepo, $formationSlotRepo) {
+                if ($className === Item::class) {
+                    return $itemRepo;
+                }
+                if ($className === \App\Entity\Formation\FormationSlot::class) {
+                    return $formationSlotRepo;
+                }
+                throw new \InvalidArgumentException("Unexpected class: $className");
+            });
+
+        $this->entityManagerMock->expects($this->once())->method('flush');
+
+        $now = new \DateTimeImmutable('2026-06-01 10:00:00');
+        $this->trainingService->promoteToTrainer($hero, $team, $now);
+
+        $this->assertSame(HeroRole::Trainer, $hero->getRole());
+        $this->assertNull($item->getEquippedHero());
+        $this->assertNull($item->getEquippedSlot());
     }
 }

--- a/translations/messages.cs.yaml
+++ b/translations/messages.cs.yaml
@@ -207,6 +207,8 @@ error:
   marketplace_cannot_bid_own: Na vlastní nabídku nelze přihazovat.
   marketplace_first_bid_minimum: 'První příhoz musí být alespoň vyvolávací cena %amount% zlata.'
   marketplace_bid_too_low: 'Příhoz je příliš nízký. Minimální další příhoz je %min% zlata (min. krok: %increment%).'
+  marketplace_buy_roster_full: Nákupem nebo příhozem by byl překročen limit soupisky.
+  marketplace_buy_trainer_limit_reached: Nákupem nebo příhozem by byl překročen limit trenérů.
   insufficient_gold: 'Nedostatek zlata. Potřeba: %required%, k dispozici: %available%.'
   insufficient_essence: 'Nedostatek esence. Potřeba: %required%, k dispozici: %available%.'
   insufficient_school_mastery: 'Nedostatečná úroveň školy. Potřeba: %required%, aktuální: %current%.'
@@ -411,6 +413,8 @@ activity:
   hero_sold: 'Hrdina %hero% (%race%) byl prodán na tržišti týmu %buyer% za %price% zlata.'
   trainer_purchased: 'Trenér %trainer% (%race%) byl zakoupen na tržišti od týmu %seller% za %price% zlata.'
   trainer_sold: 'Trenér %trainer% (%race%) byl prodán na tržišti týmu %buyer% za %price% zlata.'
+  item_purchased: 'Předmět %item% byl zakoupen na tržišti od týmu %seller% za %price% zlata.'
+  item_sold: 'Předmět %item% byl prodán na tržišti týmu %buyer% za %price% zlata.'
   team_renamed: 'Tým byl přejmenován z %old_name% na %new_name%.'
   battle_win: 'Výhra %score% proti týmu %opponent%.'
   battle_loss: 'Prohra %score% proti týmu %opponent%.'
@@ -1331,6 +1335,7 @@ arena:
   upgrade_hint: Vylepšete arénu v základně pro vyšší kapacitu a bonusy k příjmům.
 
 marketplace:
+  merchant: Obchodník
   title: Tržiště
   subtitle: Nakupujte a prodávejte hrdiny, předměty a trenéry s ostatními hráči.
   tab_browse: Procházet nabídky

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -207,6 +207,8 @@ error:
   marketplace_cannot_bid_own: You cannot bid on your own listing.
   marketplace_first_bid_minimum: 'First bid must be at least the starting bid of %amount% gold.'
   marketplace_bid_too_low: 'Bid is too low. Minimum next bid is %min% gold (min increment: %increment%).'
+  marketplace_buy_roster_full: Purchase or bid would exceed the roster limit.
+  marketplace_buy_trainer_limit_reached: Purchase or bid would exceed the trainer limit.
   insufficient_gold: 'Insufficient gold. Required: %required%, available: %available%.'
   insufficient_essence: 'Insufficient essence. Required: %required%, available: %available%.'
   insufficient_school_mastery: 'Insufficient school mastery. Required: %required%, current: %current%.'
@@ -411,6 +413,8 @@ activity:
   hero_sold: 'Hero %hero% (%race%) was sold on the marketplace to %buyer% for %price% gold.'
   trainer_purchased: 'Trainer %trainer% (%race%) was purchased on the marketplace from %seller% for %price% gold.'
   trainer_sold: 'Trainer %trainer% (%race%) was sold on the marketplace to %buyer% for %price% gold.'
+  item_purchased: 'Item %item% was purchased on the marketplace from %seller% for %price% gold.'
+  item_sold: 'Item %item% was sold on the marketplace to %buyer% for %price% gold.'
   team_renamed: 'Team was renamed from %old_name% to %new_name%.'
   battle_win: 'Won %score% against %opponent%.'
   battle_loss: 'Lost %score% against %opponent%.'
@@ -1332,6 +1336,7 @@ arena:
   upgrade_hint: Upgrade the Arena in Headquarters to increase seating capacity and revenue bonuses.
 
 marketplace:
+  merchant: Merchant
   title: Marketplace
   subtitle: Buy and sell heroes, items, and trainers with other players.
   tab_browse: Browse Listings


### PR DESCRIPTION
NpcSimulationService – přepis nákupní logiky na score-based systém; nová metoda simulateWeeklyManagementAndEconomy (HQ upgrady přesunuty do vlastní metody); prodejní logika přepracována (kandidáti se seřadí, ne jen první match); simulateMarketplaceActions oddělena
MarketplaceService – přidán check roster/trainer limitu při nákupu i bidování; přidáno entityName do transakce; oprava null listing/seller v getTransactionHistory; chronicle záznamy recordItemPurchased/Sold
MarketplaceTransaction – sellerTeam a listing jsou nullable; nové pole entityName
TeamChronicleService – přidány metody recordItemPurchased a recordItemSold; nová závislost UserMessageTranslator
TrainingService – odepnutí předmětů při promotování hrdiny na trenéra
MarketplaceService (prodej trainera) – odepnutí předmětů při vložení trainera na listing
ItemService – záznam do chroniclu + transakce při koupi předmětu od obchodníka; gold se odečítá přes EconomyService
SummoningService – countActiveCombatantsByTeam místo count(['team'])
KingdomInitializationService – Genie tým má pouze Genie hrdiny; fix inicializace sezóny (active i pro minulé datumy)
HeroRepository – nové metody countActiveCombatantsByTeam a countActiveTrainersByTeam